### PR TITLE
Refactor SRS card management into toggleDone handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -7404,10 +7404,27 @@ function App() {
   var pBg = PHASE_BG[lesson.phaseNum] || '#f8f9fa';
   var pct = Math.round(completed.size / 365 * 100);
   var toggleDone = function toggleDone() {
+    var wasDone = completed.has(dayNum);
     setCompleted(function (prev) {
       var n = new Set(prev);
       n.has(dayNum) ? n["delete"](dayNum) : n.add(dayNum);
       return n;
+    });
+    setSrsCards(function (prev) {
+      var cards = Object.assign({}, prev);
+      if (wasDone) {
+        var prefix1 = 'v_' + dayNum + '_';
+        var prefix2 = 'c_' + dayNum + '_';
+        Object.keys(cards).forEach(function (id) {
+          if (id.startsWith(prefix1) || id.startsWith(prefix2)) {
+            delete cards[id];
+          }
+        });
+      } else {
+        srsAddCards(lesson, cards);
+      }
+      srsSave(cards);
+      return cards;
     });
   };
   React.useEffect(function () {
@@ -7420,14 +7437,6 @@ function App() {
       localStorage.setItem('n5_completed', JSON.stringify(_toConsumableArray(completed)));
     } catch (e) {}
   }, [completed]);
-  React.useEffect(function () {
-    var cards = _objectSpread({}, srsCards);
-    var changed = srsAddCards(lesson, cards);
-    if (changed) {
-      setSrsCards(cards);
-      srsSave(cards);
-    }
-  }, [dayNum]);
   return /*#__PURE__*/React.createElement("div", {
     className: "app"
   }, /*#__PURE__*/React.createElement("header", {


### PR DESCRIPTION
## Summary
Moved SRS card synchronization logic from a separate `useEffect` hook into the `toggleDone` function to ensure SRS cards are updated atomically when a lesson day's completion status changes.

## Key Changes
- Integrated SRS card management directly into the `toggleDone` handler
- When marking a day as done: adds SRS cards for that lesson via `srsAddCards()`
- When marking a day as not done: removes all SRS cards associated with that day (identified by `v_` and `c_` prefixes)
- Removed the separate `useEffect` hook that was triggered on `dayNum` changes, eliminating the race condition where SRS cards could be added independently of completion status changes
- SRS card persistence (`srsSave()`) now happens as part of the toggle operation

## Implementation Details
- Captures the previous completion state (`wasDone`) before updating to determine whether to add or remove cards
- Uses prefix-based filtering (`v_${dayNum}_` and `c_${dayNum}_`) to identify and clean up cards when unmarking a day as complete
- Maintains the same SRS card state management pattern while improving the timing and atomicity of updates

https://claude.ai/code/session_01H77K55vp5vVqR9KybQtjxL