### PR TITLE
Add progressive UI translations from English to Japanese

### DIFF
--- a/curriculum.js
+++ b/curriculum.js
@@ -1,6448 +1,18450 @@
 "use strict";
 
-var curriculum = [{
-  "day": 1,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: あ行 — The 5 Vowels",
-  "intro": "Welcome to Day 1! The 5 vowels are the backbone of every Japanese sound.",
-  "type": "script",
-  "chars": [["あ", "a"], ["い", "i"], ["う", "u"], ["え", "e"], ["お", "o"]],
-  "vocab": [["いえ", "いえ", "house"], ["あお", "あお", "blue"], ["うえ", "うえ", "above / up"], ["あい", "あい", "love / indigo"], ["おい", "おい", "hey! / nephew"]],
-  "grammar": {},
-  "practice": "Write each vowel 10 times: あ い う え お. Then try reading: いえ (house)  あお (blue)  うえ (above).",
-  "tip": "Vowels: a=ah, i=ee, u=oo, e=eh, o=oh — always pronounced the same!"
-}, {
-  "day": 2,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: か行 — The K-Series",
-  "intro": "Today we learn the か行 (ka-series). These combine the k-sound with each vowel.",
-  "type": "script",
-  "chars": [["か", "ka"], ["き", "ki"], ["く", "ku"], ["け", "ke"], ["こ", "ko"]],
-  "vocab": [["かい", "かい", "shell / floor (counter)"], ["いく", "いく", "to go"], ["こえ", "こえ", "voice"], ["おか", "おか", "hill"], ["きく", "きく", "to listen / chrysanthemum"]],
-  "grammar": {},
-  "practice": "Write each か行 char 8 times. Read aloud: かい いく こえ. Every word only uses letters you know!",
-  "tip": "The k-sound is crisp: ka, ki, ku, ke, ko. Each vowel changes the sound!"
-}, {
-  "day": 3,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: さ行 — The S-Series",
-  "intro": "Time for the さ行 (sa-series). Notice that し and す have unique pronunciations.",
-  "type": "script",
-  "chars": [["さ", "sa"], ["し", "shi"], ["す", "su"], ["せ", "se"], ["そ", "so"]],
-  "vocab": [["すし", "すし", "sushi"], ["かさ", "かさ", "umbrella"], ["あさ", "あさ", "morning"], ["さけ", "さけ", "sake / salmon"], ["しか", "しか", "deer"]],
-  "grammar": {},
-  "practice": "Read: すし かさ あさ. Notice すし uses two of today's characters plus ones you already know!",
-  "tip": "Remember: し=she, す=soo. These are exceptions to the regular pattern!"
-}, {
-  "day": 4,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: た行 — The T-Series",
-  "intro": "Meet the た行 (ta-series). Like し, つ has a special pronunciation.",
-  "type": "script",
-  "chars": [["た", "ta"], ["ち", "chi"], ["つ", "tsu"], ["て", "te"], ["と", "to"]],
-  "vocab": [["うた", "うた", "song"], ["した", "した", "below / under"], ["てつ", "てつ", "iron / railway"], ["かた", "かた", "shoulder / person"], ["すてき", "すてき", "wonderful"]],
-  "grammar": {},
-  "practice": "Read aloud: うた した すてき. Try writing 'song' (うた) and 'below' (した) from memory.",
-  "tip": "Tricky sounds: ち=chee, つ=tsoo. These take practice to write cleanly!"
-}, {
-  "day": 5,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: な行 — The N-Series",
-  "intro": "The な行 (na-series) is straightforward—each character follows the pattern na, ni, nu, ne, no.",
-  "type": "script",
-  "chars": [["な", "na"], ["に", "ni"], ["ぬ", "nu"], ["ね", "ne"], ["の", "no"]],
-  "vocab": [["ねこ", "ねこ", "cat"], ["ぬの", "ぬの", "cloth / fabric"], ["なに", "なに", "what?"], ["いね", "いね", "rice plant"], ["かな", "かな", "kana (Japanese script)"]],
-  "grammar": {},
-  "practice": "Read: ねこ なに かな. Can you write 'cat' (ねこ) and 'what' (なに) from memory?",
-  "tip": "Simple and consistent: na, ni, nu, ne, no. A great series to build confidence!"
-}, {
-  "day": 6,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: は行 — The H-Series",
-  "intro": "The は行 (ha-series) introduces us to the h-sound. Note: は by itself means 'is' in grammar.",
-  "type": "script",
-  "chars": [["は", "ha"], ["ひ", "hi"], ["ふ", "fu"], ["へ", "he"], ["ほ", "ho"]],
-  "vocab": [["はな", "はな", "flower / nose"], ["ひと", "ひと", "person"], ["ふね", "ふね", "boat / ship"], ["へた", "へた", "unskillful / bad at"], ["ほし", "ほし", "star"]],
-  "grammar": {},
-  "practice": "Read: はな ひと ほし. Write 'flower' (はな) and 'star' (ほし) from memory.",
-  "tip": "Soft h-sounds: ha, hi, fu (not 'hu'), he, ho. Get the strokes right!"
-}, {
-  "day": 7,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: ま行 — The M-Series",
-  "intro": "The ま行 (ma-series) brings smooth m-sounds. These characters are fairly easy to distinguish.",
-  "type": "script",
-  "chars": [["ま", "ma"], ["み", "mi"], ["む", "mu"], ["め", "me"], ["も", "mo"]],
-  "vocab": [["まち", "まち", "town"], ["みせ", "みせ", "shop / store"], ["むし", "むし", "insect / bug"], ["めし", "めし", "meal / rice (casual)"], ["もの", "もの", "thing / object"]],
-  "grammar": {},
-  "practice": "Read: まち みせ もの. Can you write 'town' and 'thing' from memory?",
-  "tip": "Even flow: ma, mi, mu, me, mo. めがね (glasses) connects to め looking like an eye!"
-}, {
-  "day": 8,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: や行 — Three Special Characters",
-  "intro": "The や行 (ya-series) has only 3 characters: や, ゆ, よ. These create y-sounds combined with a, u, o.",
-  "type": "script",
-  "chars": [["や", "ya"], ["ゆ", "yu"], ["よ", "yo"]],
-  "vocab": [["やま", "やま", "mountain"], ["ゆき", "ゆき", "snow"], ["よこ", "よこ", "beside / sideways"], ["やさい", "やさい", "vegetable"], ["ゆみ", "ゆみ", "bow (archery) / Yumi (name)"]],
-  "grammar": {},
-  "practice": "Read: やま ゆき やさい. Write 'mountain' (やま) and 'snow' (ゆき) from memory.",
-  "tip": "Only 3 in this series! ya, yu, yo. These always have the 'y' glide."
-}, {
-  "day": 9,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: ら行 — The R-Series",
-  "intro": "The ら行 (ra-series) completes the basic hiragana. The r-sound is rolled slightly in Japanese.",
-  "type": "script",
-  "chars": [["ら", "ra"], ["り", "ri"], ["る", "ru"], ["れ", "re"], ["ろ", "ro"]],
-  "vocab": [["そら", "そら", "sky"], ["しろ", "しろ", "white / castle"], ["はる", "はる", "spring (season)"], ["みる", "みる", "to see / look at"], ["もり", "もり", "forest"]],
-  "grammar": {},
-  "practice": "Read: そら はる もり. Write 'sky' (そら) and 'forest' (もり) from memory.",
-  "tip": "Softer r-sounds than English: ra, ri, ru, re, ro. Almost between r and l!"
-}, {
-  "day": 10,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: わ、を、ん — The Final Three",
-  "intro": "Today we learn わ, を, and ん. These complete the basic hiragana set: を is almost unused, ん is crucial.",
-  "type": "script",
-  "chars": [["わ", "wa"], ["を", "wo/o"], ["ん", "n"]],
-  "vocab": [["わたし", "わたし", "I / me"], ["かわ", "かわ", "river"], ["にわ", "にわ", "garden"], ["ほん", "ほん", "book"], ["みんな", "みんな", "everyone"]],
-  "grammar": {},
-  "practice": "You now know ALL basic hiragana! Read: わたし かわ ほん みんな. Celebrate — that is huge!",
-  "tip": "ん is magical: it closes any syllable without a vowel! わ sounds like 'wa'. を is almost never used in speech!"
-}, {
-  "day": 11,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: Voiced が行・ざ行",
-  "intro": "Now we add voiced (dakuten) marks! These create g, z, d, b, p sounds from k, s, t, h, m bases.",
-  "type": "script",
-  "chars": [["が", "ga"], ["ぎ", "gi"], ["ぐ", "gu"], ["げ", "ge"], ["ご", "go"], ["ざ", "za"], ["じ", "ji"], ["ず", "zu"], ["ぜ", "ze"], ["ぞ", "zo"]],
-  "vocab": [["かぎ", "かぎ", "key"], ["かぜ", "かぜ", "wind / cold (illness)"], ["ぞう", "ぞう", "elephant"], ["じかん", "じかん", "time"], ["がくせい", "がくせい", "student"]],
-  "grammar": {},
-  "practice": "Read: かぎ かぜ ぞう じかん. Notice how adding ﾞ (dakuten) changes the sound!",
-  "tip": "Dakuten (゛) adds voicing: か→が, さ→ざ, た→だ, は→ば. It changes everything!"
-}, {
-  "day": 12,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: Voiced だ行・ば行・ぱ行",
-  "intro": "Continue with more voiced characters plus the semi-voiced (handakuten) ぱ行 marks. Nearly 50 characters now!",
-  "type": "script",
-  "chars": [["だ", "da"], ["で", "de"], ["ど", "do"], ["ば", "ba"], ["び", "bi"], ["ぶ", "bu"], ["べ", "be"], ["ぼ", "bo"], ["ぱ", "pa"], ["ぴ", "pi"], ["ぷ", "pu"], ["ぺ", "pe"], ["ぽ", "po"]],
-  "vocab": [["でんわ", "でんわ", "telephone"], ["どうぞ", "どうぞ", "please / go ahead"], ["からだ", "からだ", "body"], ["ぼうし", "ぼうし", "hat"], ["だれ", "だれ", "who?"]],
-  "grammar": {},
-  "practice": "Read: でんわ どうぞ だれ. Practice the voiced (゛) and semi-voiced (゜) sounds.",
-  "tip": "Semi-voiced is special: は→ぱ (adding ゜). Remember: ゛ for g/z/d/b, ゜ only for p!"
-}, {
-  "day": 13,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: Combination Characters (拗音)",
-  "intro": "Combine small や, ゆ, よ with other characters to create palatalized sounds like kya, sho, cha, ryu.",
-  "type": "script",
-  "chars": [["きゃ", "kya"], ["きゅ", "kyu"], ["きょ", "kyo"], ["しゃ", "sha"], ["しゅ", "shu"], ["しょ", "sho"], ["ちゃ", "cha"], ["ちゅ", "chu"], ["ちょ", "cho"], ["じゃ", "ja"], ["じゅ", "ju"], ["じょ", "jo"], ["りゅ", "ryu"], ["りょ", "ryo"]],
-  "vocab": [["きょう", "きょう", "today"], ["しゃしん", "しゃしん", "photograph"], ["じゃあ", "じゃあ", "well then / OK then"], ["りょこう", "りょこう", "travel / trip"], ["びょういん", "びょういん", "hospital"]],
-  "grammar": {},
-  "practice": "Read: きょう しゃしん りょこう. Practice saying the small-や/ゆ/よ combos quickly.",
-  "tip": "Combination magic: き+ゃ=きゃ. These are ONE sound, not two! Critical for reading."
-}, {
-  "day": 14,
-  "phaseNum": 1,
-  "phaseName": "Hiragana",
-  "week": 1,
-  "title": "Hiragana: Special Rules & Full Review",
-  "intro": "Master the double consonant (っ) for emphasis and the long vowel mark (ー) used mainly in katakana. Review everything!",
-  "type": "script",
-  "chars": [["っ", "double"], ["ー", "long vowel"]],
-  "vocab": [["おかあさん", "おかあさん", "mother"], ["きって", "きって", "stamp"], ["がっこう", "がっこう", "school"], ["ゆっくり", "ゆっくり", "slowly"], ["ざっし", "ざっし", "magazine"]],
-  "grammar": {},
-  "practice": "Write the entire hiragana chart from memory. Then read: がっこう、きって、おかあさん",
-  "tip": "っ doubles the next consonant. ー rarely appears in hiragana but very common in katakana!"
-}, {
-  "day": 15,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: ア行 — The 5 Vowels",
-  "intro": "Welcome to katakana! These characters represent the same sounds as hiragana but are used for foreign words.",
-  "type": "script",
-  "chars": [["ア", "a"], ["イ", "i"], ["ウ", "u"], ["エ", "e"], ["オ", "o"]],
-  "vocab": [["アイスクリーム", "アイスクリーム", "ice cream"], ["イタリア", "イタリア", "Italy"], ["ウイスキー", "ウイスキー", "whisky"], ["エレベーター", "エレベーター", "elevator"], ["オレンジ", "オレンジ", "orange"]],
-  "grammar": {},
-  "practice": "Write each character 10 times. Compare with hiragana—sounds are identical, shapes are angular.",
-  "tip": "Katakana = foreign words, sound effects, emphasis. Learn the angular shapes now!"
-}, {
-  "day": 16,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: カ行 — The K-Series",
-  "intro": "The カ行 in katakana uses the same sounds as か行 but with straighter, more angular strokes.",
-  "type": "script",
-  "chars": [["カ", "ka"], ["キ", "ki"], ["ク", "ku"], ["ケ", "ke"], ["コ", "ko"]],
-  "vocab": [["カメラ", "カメラ", "camera"], ["キッチン", "キッチン", "kitchen"], ["クラス", "クラス", "class"], ["ケーキ", "ケーキ", "cake"], ["コーヒー", "コーヒー", "coffee"]],
-  "grammar": {},
-  "practice": "Write each character 8 times. Notice the strong angular lines compared to hiragana.",
-  "tip": "Katakana is more geometric! These are loanwords, so sounds might feel foreign at first."
-}, {
-  "day": 17,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: サ行 — The S-Series",
-  "intro": "The サ行 continues the pattern. シ and ス again have special sounds like in hiragana.",
-  "type": "script",
-  "chars": [["サ", "sa"], ["シ", "shi"], ["ス", "su"], ["セ", "se"], ["ソ", "so"]],
-  "vocab": [["サッカー", "サッカー", "soccer"], ["シャツ", "シャツ", "shirt"], ["スポーツ", "スポーツ", "sports"], ["セーター", "セーター", "sweater"], ["ソファ", "ソファ", "sofa"]],
-  "grammar": {},
-  "practice": "Write each character 8 times. Recognize that these sounds match hiragana exactly.",
-  "tip": "Same sounds, different look! Get comfortable with the angular katakana form."
-}, {
-  "day": 18,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: タ行 — The T-Series",
-  "intro": "The タ行 follows the katakana pattern. チ and ツ retain their special pronunciations.",
-  "type": "script",
-  "chars": [["タ", "ta"], ["チ", "chi"], ["ツ", "tsu"], ["テ", "te"], ["ト", "to"]],
-  "vocab": [["タクシー", "タクシー", "taxi"], ["チケット", "チケット", "ticket"], ["ツアー", "ツアー", "tour"], ["テレビ", "テレビ", "TV"], ["トイレ", "トイレ", "toilet"]],
-  "grammar": {},
-  "practice": "Write each character 8 times. チ (chi) and ツ (tsu) are instantly recognizable once learned.",
-  "tip": "Notice how チ looks like ちの angular cousin, and ツ is parallel lines—easy to distinguish!"
-}, {
-  "day": 19,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: ナ行 — The N-Series",
-  "intro": "The ナ行 is straightforward with consistent patterns, just like in hiragana.",
-  "type": "script",
-  "chars": [["ナ", "na"], ["ニ", "ni"], ["ヌ", "nu"], ["ネ", "ne"], ["ノ", "no"]],
-  "vocab": [["ナイフ", "ナイフ", "knife"], ["ニュース", "ニュース", "news"], ["ヌードル", "ヌードル", "noodle"], ["ネクタイ", "ネクタイ", "necktie"], ["ノート", "ノート", "notebook"]],
-  "grammar": {},
-  "practice": "Write each character 8 times. These are simple, regular sounds good for building speed.",
-  "tip": "Consistent sounds: na, ni, nu, ne, no. Perfect for building reading confidence!"
-}, {
-  "day": 20,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: ハ行 — The H-Series",
-  "intro": "The ハ行 maintains the same sounds as hiragana but with the distinctive katakana angular style.",
-  "type": "script",
-  "chars": [["ハ", "ha"], ["ヒ", "hi"], ["フ", "fu"], ["ヘ", "he"], ["ホ", "ho"]],
-  "vocab": [["ハンバーガー", "ハンバーガー", "hamburger"], ["ヒーター", "ヒーター", "heater"], ["フランス", "フランス", "France"], ["ヘルメット", "ヘルメット", "helmet"], ["ホテル", "ホテル", "hotel"]],
-  "grammar": {},
-  "practice": "Write each character 8 times. Pay attention to the shape of フ (fu)—very distinctive.",
-  "tip": "Angular and strong: ha, hi, fu, he, ho. フ looks like a hook—great memory aid!"
-}, {
-  "day": 21,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: マ行 — The M-Series",
-  "intro": "The マ行 continues with the m-sounds. These characters are fairly distinctive in katakana too.",
-  "type": "script",
-  "chars": [["マ", "ma"], ["ミ", "mi"], ["ム", "mu"], ["メ", "me"], ["モ", "mo"]],
-  "vocab": [["マナー", "マナー", "manners"], ["ミルク", "ミルク", "milk"], ["ムード", "ムード", "mood"], ["メニュー", "メニュー", "menu"], ["モデル", "モデル", "model"]],
-  "grammar": {},
-  "practice": "Write each character 8 times. メ looks clean and angular, good for quick recall.",
-  "tip": "Smooth m-sounds: ma, mi, mu, me, mo. メ is like a stylized 'me'—clean lines!"
-}, {
-  "day": 22,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: ヤ行 — Three Special Characters",
-  "intro": "The ヤ行 has only 3 characters, just like in hiragana: ヤ, ユ, ヨ with their y-glide sounds.",
-  "type": "script",
-  "chars": [["ヤ", "ya"], ["ユ", "yu"], ["ヨ", "yo"]],
-  "vocab": [["ヤード", "ヤード", "yard"], ["ユーモア", "ユーモア", "humor"], ["ヨーロッパ", "ヨーロッパ", "Europe"], ["ユニフォーム", "ユニフォーム", "uniform"], ["ヤッホー", "ヤッホー", "yoo-hoo"]],
-  "grammar": {},
-  "practice": "Write each character 10 times. Remember: still only 3 in this series, same as hiragana.",
-  "tip": "Only 3 again! ya, yu, yo. No ヤ行 for 'i' and 'e'—that's by design!"
-}, {
-  "day": 23,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: ラ行 — The R-Series",
-  "intro": "The ラ行 completes the basic katakana characters. The r-sounds remain gentle, between r and l.",
-  "type": "script",
-  "chars": [["ラ", "ra"], ["リ", "ri"], ["ル", "ru"], ["レ", "re"], ["ロ", "ro"]],
-  "vocab": [["ラジオ", "ラジオ", "radio"], ["リモコン", "リモコン", "remote control"], ["ルール", "ルール", "rule"], ["レストラン", "レストラン", "restaurant"], ["ロビー", "ロビー", "lobby"]],
-  "grammar": {},
-  "practice": "Write each character 8 times. These angular forms complete the 'basic 5x5'.",
-  "tip": "Softer r-sounds in Japanese: ra, ri, ru, re, ro. You've now learned 50 basic characters!"
-}, {
-  "day": 24,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: ワ行 + Long Vowel Mark",
-  "intro": "The ワ行 in katakana introduces ワ (wa) and ン (n), plus the long vowel mark ー widely used in katakana.",
-  "type": "script",
-  "chars": [["ワ", "wa"], ["ン", "n"], ["ー", "long vowel"]],
-  "vocab": [["ワイン", "ワイン", "wine"], ["テーブル", "テーブル", "table"], ["コーヒー", "コーヒー", "coffee"], ["パン", "パン", "bread"], ["ランチ", "ランチ", "lunch"]],
-  "grammar": {},
-  "practice": "Write ワ and ン 10 times. Notice ー extending vowels: コーヒー has two long marks.",
-  "tip": "The dash ー is KEY in katakana! It stretches vowels: コ-ヒー means 'kohiiii'. Essential!"
-}, {
-  "day": 25,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: Voiced ガ行・ザ行",
-  "intro": "Add voiced marks to katakana now! These create g, z sounds, doubling your inventory.",
-  "type": "script",
-  "chars": [["ガ", "ga"], ["ギ", "gi"], ["グ", "gu"], ["ゲ", "ge"], ["ゴ", "go"], ["ザ", "za"], ["ジ", "ji"], ["ズ", "zu"], ["ゼ", "ze"], ["ゾ", "zo"]],
-  "vocab": [["ゲーム", "ゲーム", "game"], ["ガイド", "ガイド", "guide"], ["グループ", "グループ", "group"], ["ジュース", "ジュース", "juice"], ["ゾーン", "ゾーン", "zone"]],
-  "grammar": {},
-  "practice": "Write each character 6 times. Dakuten (゛) works identically on katakana.",
-  "tip": "Same voiced pattern as hiragana! カ→ガ, サ→ザ. The rules are consistent!"
-}, {
-  "day": 26,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: Voiced ダ行・バ行・パ行",
-  "intro": "Continue with more voiced characters and the semi-voiced ぱ行. Nearly there with katakana basics!",
-  "type": "script",
-  "chars": [["ダ", "da"], ["デ", "de"], ["ド", "do"], ["バ", "ba"], ["ビ", "bi"], ["ブ", "bu"], ["ベ", "be"], ["ボ", "bo"], ["パ", "pa"], ["ピ", "pi"], ["プ", "pu"], ["ペ", "pe"], ["ポ", "po"]],
-  "vocab": [["バス", "バス", "bus"], ["ピアノ", "ピアノ", "piano"], ["プール", "プール", "pool"], ["ペン", "ペン", "pen"], ["ポスター", "ポスター", "poster"]],
-  "grammar": {},
-  "practice": "Write each character 5 times. Handakuten (゜) creates the p-sound, same as hiragana.",
-  "tip": "Consistent rule: ゛ for g/z/d/b, ゜ for p only. You've mastered this pattern already!"
-}, {
-  "day": 27,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 3,
-  "title": "Katakana: Combinations & Special Sounds",
-  "intro": "Master combination characters with small ヤ, ユ, ヨ, plus special sounds like ファ (fa), ティ (ti).",
-  "type": "script",
-  "chars": [["シャ", "sha"], ["チャ", "cha"], ["ジャ", "ja"], ["ティ", "ti"], ["ファ", "fa"], ["フィ", "fi"]],
-  "vocab": [["シャワー", "シャワー", "shower"], ["チャンス", "チャンス", "chance"], ["ジャム", "ジャム", "jam"], ["ティッシュ", "ティッシュ", "tissue"], ["ファッション", "ファッション", "fashion"]],
-  "grammar": {},
-  "practice": "Write each combination 5 times. These blend sounds, creating new phonemes for foreign words.",
-  "tip": "Combinations are ONE sound! シャ=sha, not 'si-ya'. Crucial for loanword reading!"
-}, {
-  "day": 28,
-  "phaseNum": 2,
-  "phaseName": "Katakana",
-  "week": 4,
-  "title": "Katakana: Full Review & Loanword Practice",
-  "intro": "Congratulations! You've learned all basic katakana. Today we practice common loanwords and review the full chart.",
-  "type": "script",
-  "chars": [],
-  "vocab": [["レストラン", "レストラン", "restaurant"], ["スマートフォン", "スマートフォン", "smartphone"], ["コンビニ", "コンビニ", "convenience store"], ["アパート", "アパート", "apartment"], ["パスポート", "パスポート", "passport"]],
-  "grammar": {},
-  "practice": "Write the complete katakana chart from memory. Then read: スマートフォン、パスポート、アパート",
-  "tip": "You now read and write 100+ character combinations! Katakana unlocks the loanword world!"
-}, {
-  "day": 29,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 5,
-  "title": "Numbers 1–5",
-  "intro": "Numbers are essential for everything — prices, times, dates. Today: 1 to 5.",
-  "type": "numbers",
-  "chars": [["いち", "1"], ["に", "2"], ["さん", "3"], ["し/よん", "4"], ["ご", "5"]],
-  "vocab": [["いちえん", "いちえん", "1 yen"], ["にほん", "にほん", "2 (long objects)"], ["さんにん", "さんにん", "3 people"], ["よにん", "よにん", "4 people"], ["ごふん", "ごふん", "5 minutes"]],
-  "grammar": {
-    "pattern": "〜えんです",
-    "meaning": "It is ~ yen",
-    "example_jp": "ひゃくえんです",
-    "example_en": "It is 100 yen"
-  },
-  "practice": "Say 1-5 aloud 10 times. Then count objects around you in Japanese.",
-  "tip": "し(4) can also be read よん — よん is safer as し sounds like 'death'."
-}, {
-  "day": 30,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 5,
-  "title": "Numbers 6–10",
-  "intro": "Completing 1–10 today! These ten numbers unlock prices, ages, and counting.",
-  "type": "numbers",
-  "chars": [["ろく", "6"], ["なな/しち", "7"], ["はち", "8"], ["きゅう/く", "9"], ["じゅう", "10"]],
-  "vocab": [["ろっぽん", "ろっぽん", "6 (long objects)"], ["ななじ", "ななじ", "7 o'clock"], ["はちえん", "はちえん", "8 yen"], ["きゅうにん", "きゅうにん", "9 people"], ["じゅっぷん", "じゅっぷん", "10 minutes"]],
-  "grammar": {},
-  "practice": "Count backwards from 10 to 1. Then practice: 3+4=? in Japanese (さん たす よん は なな).",
-  "tip": "なな(7) is safer than しち in some contexts. きゅう(9) is safer than く which means suffering."
-}, {
-  "day": 31,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 5,
-  "title": "Numbers 11–100",
-  "intro": "From 11 onwards, Japanese numbers are logical: 11 = ten-one (じゅういち).",
-  "type": "numbers",
-  "chars": [["じゅういち", "11"], ["じゅうに", "12"], ["にじゅう", "20"], ["さんじゅう", "30"], ["ひゃく", "100"]],
-  "vocab": [["じゅうごえん", "じゅうごえん", "15 yen"], ["にじゅうさい", "にじゅうさい", "20 years old"], ["さんじゅうにん", "さんじゅうにん", "30 people"], ["ごじゅっぷん", "ごじゅっぷん", "50 minutes"], ["ひゃくえん", "ひゃくえん", "100 yen"]],
-  "grammar": {},
-  "practice": "Write out: 13, 27, 45, 68, 99 in Japanese. Check your answers.",
-  "tip": "The pattern is simple: tens digit + じゅう + ones digit. 47 = よんじゅうなな. No exceptions!"
-}, {
-  "day": 32,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 5,
-  "title": "Numbers: Hundreds & Thousands",
-  "intro": "Big numbers! 100=ひゃく, 1000=せん, 10000=まん. Japan uses まん (10,000) as a unit.",
-  "type": "numbers",
-  "chars": [["ひゃく", "100"], ["せん", "1,000"], ["まん", "10,000"], ["いちまん", "10,000"], ["じゅうまん", "100,000"]],
-  "vocab": [["さんびゃくえん", "さんびゃくえん", "300 yen"], ["ごせんえん", "ごせんえん", "5,000 yen"], ["いちまんえん", "いちまんえん", "10,000 yen"], ["にまんごせん", "にまんごせん", "25,000"], ["ひゃくまん", "ひゃくまん", "1,000,000"]],
-  "grammar": {},
-  "practice": "Practice saying prices: ¥350, ¥1,200, ¥15,000, ¥98,000.",
-  "tip": "Note: 300=さんびゃく, 600=ろっぴゃく, 800=はっぴゃく (irregular!). 3000=さんぜん, 8000=はっせん."
-}, {
-  "day": 33,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 5,
-  "title": "Counters: まい・ほん・ひき",
-  "intro": "Japanese uses special counters depending on what's being counted. Today: flat things, long things, small animals.",
-  "type": "numbers",
-  "chars": [["〜まい", "flat things"], ["〜ほん", "long thin things"], ["〜ひき", "small animals"], ["〜だい", "machines"], ["〜さつ", "bound books"]],
-  "vocab": [["かみ　いちまい", "かみ　いちまい", "1 sheet of paper"], ["えんぴつ　にほん", "えんぴつ　にほん", "2 pencils"], ["ねこ　さんびき", "ねこ　さんびき", "3 cats"], ["くるま　よんだい", "くるま　よんだい", "4 cars"], ["ほん　ごさつ", "ほん　ごさつ", "5 books"]],
-  "grammar": {
-    "pattern": "〜を　Nまい　ください",
-    "meaning": "Please give me N (flat things)",
-    "example_jp": "きって　を　にまい　ください",
-    "example_en": "Please give me 2 stamps"
-  },
-  "practice": "Count: 3 sheets of paper, 2 pens, 4 cats, 1 car, 5 books — in Japanese.",
-  "tip": "Counters cause sound changes: 1 pencil = いっぽん, 6 pencils = ろっぽん, 8 = はっぽん. Listen and repeat!"
-}, {
-  "day": 34,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 5,
-  "title": "Counters: 〜つ・〜個・人",
-  "intro": "Generic counter 〜つ works for most objects (1-10 only). 〜こ for small objects. 〜にん for people.",
-  "type": "numbers",
-  "chars": [["ひとつ", "1 (general)"], ["ふたつ", "2 (general)"], ["みっつ", "3"], ["よっつ", "4"], ["いつつ", "5"]],
-  "vocab": [["むっつ", "むっつ", "6 (general)"], ["ななつ", "ななつ", "7"], ["やっつ", "やっつ", "8"], ["ここのつ", "ここのつ", "9"], ["とお", "とお", "10"]],
-  "grammar": {
-    "pattern": "Nにん",
-    "meaning": "N people",
-    "example_jp": "かぞくは　よにんです",
-    "example_en": "My family has 4 people"
-  },
-  "practice": "Memorize ひとつ through とお. They're irregular but very common in daily speech.",
-  "tip": "ひとつ～とお are native Japanese numbers (和語). They're used for general counting up to 10. Beyond 10, use じゅういち style."
-}, {
-  "day": 35,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 5,
-  "title": "Numbers Review & Prices",
-  "intro": "Putting numbers into real-world context: shopping, prices, ages.",
-  "type": "numbers",
-  "chars": [],
-  "vocab": [["いくらですか", "いくらですか", "How much is it?"], ["〜えんです", "〜えんです", "It is ~ yen"], ["たかい", "たかい", "expensive"], ["やすい", "やすい", "cheap"], ["おつり", "おつり", "change (money)"]],
-  "grammar": {
-    "pattern": "〜えんです",
-    "meaning": "It is ~ yen",
-    "example_jp": "これは　さんびゃくえんです",
-    "example_en": "This is 300 yen"
-  },
-  "practice": "Practice: How would you say ¥480? ¥1,350? ¥22,000? Write them out in Japanese.",
-  "tip": "In Japan, tax (消費税 しょうひぜい) is added at checkout. Prices on tags are often before tax!"
-}, {
-  "day": 36,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 6,
-  "title": "Telling Time: Hours",
-  "intro": "〜じ = o'clock. いちじ=1:00, にじ=2:00... Learn to tell time on the hour.",
-  "type": "lesson",
-  "chars": [["〜じ", "o'clock"], ["なんじ", "what time"], ["ごぜん", "AM"], ["ごご", "PM"], ["はん", "half past"]],
-  "vocab": [["いちじ", "いちじ", "1 o'clock"], ["さんじはん", "さんじはん", "3:30"], ["ごぜんくじ", "ごぜんくじ", "9 AM"], ["ごごにじ", "ごごにじ", "2 PM"], ["なんじですか", "なんじですか", "What time is it?"]],
-  "grammar": {
-    "pattern": "いま　なんじですか",
-    "meaning": "What time is it now?",
-    "example_jp": "いま　ごぜん　じゅうじです",
-    "example_en": "It is 10 AM now"
-  },
-  "practice": "Practice saying these times: 7:00, 12:00, 3:30, 6:00 PM, 11:30 PM.",
-  "tip": "4 o'clock = よじ (not しじ!). 9 o'clock = くじ. These two are irregular — memorise them."
-}, {
-  "day": 37,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 6,
-  "title": "Telling Time: Minutes",
-  "intro": "〜ふん/ぷん = minutes. Combined with hours: さんじごふん = 3:05.",
-  "type": "lesson",
-  "chars": [["〜ふん", "minutes"], ["〜ぷん", "minutes (after certain numbers)"], ["なんぷん", "how many minutes"], ["ちょうど", "exactly"], ["ごろ", "approximately"]],
-  "vocab": [["さんじごふん", "さんじごふん", "3:05"], ["じゅうにじよんじゅっぷん", "じゅうにじよんじゅっぷん", "12:40"], ["しちじはん", "しちじはん", "7:30"], ["ごごくじじゅうごふん", "ごごくじじゅうごふん", "9:15 PM"], ["ちょうどじゅうじ", "ちょうどじゅうじ", "exactly 10:00"]],
-  "grammar": {
-    "pattern": "〜じ　〜ふんです",
-    "meaning": "It is ~h ~min",
-    "example_jp": "にじ　さんじゅっぷんです",
-    "example_en": "It is 2:30"
-  },
-  "practice": "Practice reading these times: 8:15, 10:45, 1:20, 6:55, 11:30.",
-  "tip": "Minutes with sound changes: 1min=いっぷん, 6=ろっぷん, 8=はっぷん, 10=じゅっぷん. The rest use ふん."
-}, {
-  "day": 38,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 6,
-  "title": "Yesterday, Today, Tomorrow",
-  "intro": "Core time words for daily conversation. Also: morning/afternoon/evening.",
-  "type": "lesson",
-  "chars": [["きのう", "yesterday"], ["きょう", "today"], ["あした", "tomorrow"], ["あさ", "morning"], ["よる", "night"]],
-  "vocab": [["おととい", "おととい", "the day before yesterday"], ["あさって", "あさって", "the day after tomorrow"], ["ひるごろ", "ひるごろ", "around noon"], ["まいにち", "まいにち", "every day"], ["いつ", "いつ", "when"]],
-  "grammar": {
-    "pattern": "いつ　〜ますか",
-    "meaning": "When will you ~?",
-    "example_jp": "いつ　にほんへ　いきますか",
-    "example_en": "When will you go to Japan?"
-  },
-  "practice": "Make sentences: What did you do yesterday? What will you do tomorrow?",
-  "tip": "きょう、あした、あさって — each adds a day. きのう、おととい — each goes back a day. Simple pattern!"
-}, {
-  "day": 39,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 6,
-  "title": "Days of the Week",
-  "intro": "The 7 days all end in ようび. Each is named after a natural element.",
-  "type": "lesson",
-  "chars": [["にちようび", "Sunday (sun)"], ["げつようび", "Monday (moon)"], ["かようび", "Tuesday (fire)"], ["すいようび", "Wednesday (water)"], ["もくようび", "Thursday (wood)"]],
-  "vocab": [["きんようび", "きんようび", "Friday (gold)"], ["どようび", "どようび", "Saturday (earth)"], ["なんようびですか", "なんようびですか", "What day is it?"], ["らいしゅう", "らいしゅう", "next week"], ["せんしゅう", "せんしゅう", "last week"]],
-  "grammar": {
-    "pattern": "〜ようびに　〜します",
-    "meaning": "On ~ day, I will ~",
-    "example_jp": "きんようびに　えいがを　みます",
-    "example_en": "On Friday, I'll watch a movie"
-  },
-  "practice": "Memorize the order: 日月火水木金土. Say them as a rhythm: ni-chi-ge-tsu-ka-sui-moku-kin-do.",
-  "tip": "Memory trick: Sun-Moon-Fire-Water-Wood-Gold-Earth. Each day is named after a celestial body or element!"
-}, {
-  "day": 40,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 6,
-  "title": "Months of the Year",
-  "intro": "Simple! Just number + がつ. いちがつ=January, にがつ=February, etc.",
-  "type": "lesson",
-  "chars": [["いちがつ", "January"], ["にがつ", "February"], ["さんがつ", "March"], ["しがつ", "April"], ["ごがつ", "May"]],
-  "vocab": [["ろくがつ", "ろくがつ", "June"], ["しちがつ", "しちがつ", "July"], ["はちがつ", "はちがつ", "August"], ["くがつ", "くがつ", "September"], ["じゅうがつ", "じゅうがつ", "October"], ["じゅういちがつ", "じゅういちがつ", "November"], ["じゅうにがつ", "じゅうにがつ", "December"]],
-  "grammar": {
-    "pattern": "〜がつ　〜にち",
-    "meaning": "Month ~ Day ~",
-    "example_jp": "さんがつ　みっかです",
-    "example_en": "It is March 3rd"
-  },
-  "practice": "What month is your birthday? Say it in Japanese. What month is it now?",
-  "tip": "No exceptions! Every month is just number+がつ. Much easier than English month names!"
-}, {
-  "day": 41,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 6,
-  "title": "Dates: Day Numbers",
-  "intro": "Days of the month use special readings for 1-10 and 14, 20, 24.",
-  "type": "lesson",
-  "chars": [["ついたち", "1st"], ["ふつか", "2nd"], ["みっか", "3rd"], ["よっか", "4th"], ["いつか", "5th"]],
-  "vocab": [["むいか", "むいか", "6th"], ["なのか", "なのか", "7th"], ["ようか", "ようか", "8th"], ["ここのか", "ここのか", "9th"], ["とおか", "とおか", "10th"], ["じゅうよっか", "じゅうよっか", "14th"], ["はつか", "はつか", "20th"], ["にじゅうよっか", "にじゅうよっか", "24th"]],
-  "grammar": {
-    "pattern": "〜がつ　〜にちです",
-    "meaning": "It is ~ month, ~ day",
-    "example_jp": "たんじょうびは　しちがつ　ここのかです",
-    "example_en": "My birthday is July 9th"
-  },
-  "practice": "Memorise the special readings: 1st-10th, 14th, 20th, 24th. The rest use にち (e.g. じゅうごにち=15th).",
-  "tip": "Most days = number+にち. But 1-10 are native Japanese readings (ついたち、ふつか...) — these MUST be memorised!"
-}, {
-  "day": 42,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 6,
-  "title": "Time & Date Review",
-  "intro": "Putting together time, days, months and dates in real sentences.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["らいしゅうの　もくようび", "らいしゅうの　もくようび", "next Thursday"], ["ごがつ　いつか", "ごがつ　いつか", "May 5th"], ["ごごさんじはん", "ごごさんじはん", "3:30 PM"], ["まいあさ　ろくじ", "まいあさ　ろくじ", "every morning at 6"], ["〜からです", "〜からです", "it starts from ~"]],
-  "grammar": {
-    "pattern": "〜から　〜まで",
-    "meaning": "from ~ until ~",
-    "example_jp": "くじから　ごじまで　はたらきます",
-    "example_en": "I work from 9 to 5"
-  },
-  "practice": "Write your daily schedule in Japanese: wake up time, school/work hours, sleep time.",
-  "tip": "Combine everything: ごがつ みっか（かようび）の　ごごにじはんに　あいましょう！ (Let's meet on Tuesday, May 3rd at 2:30 PM!)"
-}, {
-  "day": 43,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 7,
-  "title": "Basic Greetings",
-  "intro": "The essential Japanese greetings you'll use every single day.",
-  "type": "lesson",
-  "chars": [["おはようございます", "good morning (polite)"], ["こんにちは", "good afternoon/hello"], ["こんばんは", "good evening"], ["おやすみなさい", "good night"], ["さようなら", "goodbye"]],
-  "vocab": [["おはよう", "おはよう", "good morning (casual)"], ["じゃあね", "じゃあね", "see ya (casual)"], ["またあした", "またあした", "see you tomorrow"], ["いってきます", "いってきます", "I'm heading out"], ["いってらっしゃい", "いってらっしゃい", "Have a safe trip (response)"]],
-  "grammar": {
-    "pattern": "おはようございます",
-    "meaning": "Good morning (polite)",
-    "example_jp": "おはようございます！きょうもよろしくおねがいします",
-    "example_en": "Good morning! I look forward to working with you today"
-  },
-  "practice": "Practice greeting sequences: morning → afternoon → evening → night. Also the いってきます/いってらっしゃい pair.",
-  "tip": "Japanese greetings change by time of day. おはよう before ~10am, こんにちは ~10am-6pm, こんばんは after ~6pm."
-}, {
-  "day": 44,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 7,
-  "title": "Polite Expressions",
-  "intro": "Thank you, excuse me, sorry — the essential politeness toolkit.",
-  "type": "lesson",
-  "chars": [["ありがとうございます", "thank you (polite)"], ["すみません", "excuse me / sorry"], ["もうしわけありません", "I am very sorry"], ["どういたしまして", "you're welcome"], ["おねがいします", "please (requesting)"]],
-  "vocab": [["ありがとう", "ありがとう", "thank you (casual)"], ["ごめんなさい", "ごめんなさい", "I'm sorry"], ["だいじょうぶです", "だいじょうぶです", "It's OK / I'm fine"], ["はい", "はい", "yes"], ["いいえ", "いいえ", "no"]],
-  "grammar": {
-    "pattern": "〜を　おねがいします",
-    "meaning": "Please (give me / do) ~",
-    "example_jp": "コーヒーを　おねがいします",
-    "example_en": "A coffee please"
-  },
-  "practice": "Role-play: bump into someone (すみません), receive a gift (ありがとうございます), someone thanks you (どういたしまして).",
-  "tip": "すみません is incredibly versatile — use it to get attention, apologize mildly, or say 'excuse me'. One of Japan's most used words!"
-}, {
-  "day": 45,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 7,
-  "title": "Self Introduction",
-  "intro": "はじめまして！Learn how to introduce yourself in Japanese.",
-  "type": "lesson",
-  "chars": [["はじめまして", "nice to meet you"], ["〜といいます", "my name is ~"], ["〜からきました", "I'm from ~"], ["〜をしています", "I work as / I do ~"], ["よろしくおねがいします", "pleased to meet you"]],
-  "vocab": [["わたしは〜です", "わたしは〜です", "I am ~"], ["しゅっしんは〜です", "しゅっしんは〜です", "I'm from ~ (hometown)"], ["しごとは〜です", "しごとは〜です", "My job is ~"], ["しゅみは〜です", "しゅみは〜です", "My hobby is ~"], ["よろしく", "よろしく", "nice to meet you (casual)"]],
-  "grammar": {
-    "pattern": "はじめまして。〜といいます",
-    "meaning": "Nice to meet you. My name is ~",
-    "example_jp": "はじめまして。アランといいます。アメリカからきました。よろしくおねがいします",
-    "example_en": "Nice to meet you. My name is Alan. I'm from America. Pleased to meet you"
-  },
-  "practice": "Write your own self-introduction: name, country, occupation/study, hobby. Memorise it!",
-  "tip": "〜といいます is more humble than 〜です for your name. Always end with よろしくおねがいします — it's essential etiquette!"
-}, {
-  "day": 46,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 7,
-  "title": "At a Shop / Restaurant",
-  "intro": "Essential phrases for shopping and dining — phrases you'll need in Japan!",
-  "type": "lesson",
-  "chars": [["いらっしゃいませ", "welcome (shop/restaurant)"], ["〜をください", "please give me ~"], ["いくらですか", "how much is it?"], ["〜をひとつ", "one of ~"], ["おかいけい", "the bill / check"]],
-  "vocab": [["メニューをみせてください", "メニューをみせてください", "Please show me the menu"], ["これにします", "これにします", "I'll have this"], ["おすすめは？", "おすすめは？", "What do you recommend?"], ["テイクアウトで", "テイクアウトで", "To go / takeaway"], ["カードでもいいですか", "カードでもいいですか", "Can I pay by card?"]],
-  "grammar": {
-    "pattern": "〜を　ひとつ　ください",
-    "meaning": "One ~ please",
-    "example_jp": "コーヒーを　ふたつ　ください",
-    "example_en": "Two coffees please"
-  },
-  "practice": "Practise ordering: a coffee, two sandwiches, and asking for the bill. Role-play at a restaurant.",
-  "tip": "You don't need to say 'I want' in Japanese — just say the item + をください. Much more direct than English!"
-}, {
-  "day": 47,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 7,
-  "title": "Asking for Help",
-  "intro": "Can't understand? Need directions? These phrases will save you.",
-  "type": "lesson",
-  "chars": [["わかりません", "I don't understand"], ["もういちど　いってください", "please say it again"], ["ゆっくり　はなしてください", "please speak slowly"], ["〜はどこですか", "where is ~?"], ["〜をしっていますか", "do you know ~?"]],
-  "vocab": [["えいごが　わかりますか", "えいごが　わかりますか", "Do you understand English?"], ["かいてください", "かいてください", "Please write it"], ["おしえてください", "おしえてください", "Please tell/teach me"], ["たすけてください", "たすけてください", "Please help me"], ["きんきゅうじたい", "きんきゅうじたい", "emergency"]],
-  "grammar": {
-    "pattern": "〜は　どこですか",
-    "meaning": "Where is ~?",
-    "example_jp": "トイレは　どこですか",
-    "example_en": "Where is the bathroom?"
-  },
-  "practice": "Practice: 'I don't understand, please repeat slowly' and 'Where is the station?' until smooth.",
-  "tip": "Don't be embarrassed to use わかりません！Japanese people appreciate the effort to communicate even imperfectly."
-}, {
-  "day": 48,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 7,
-  "title": "Daily Life Phrases",
-  "intro": "Common phrases for school, work, and everyday situations.",
-  "type": "lesson",
-  "chars": [["おはようございます", "good morning (at work/school)"], ["おつかれさまでした", "good work / thanks for your effort"], ["いただきます", "let's eat (before meals)"], ["ごちそうさまでした", "thank you for the meal (after)"], ["しつれいします", "excuse me / I'm leaving"]],
-  "vocab": [["ちょっとまってください", "ちょっとまってください", "Please wait a moment"], ["あとで", "あとで", "later"], ["いそいでいます", "いそいでいます", "I'm in a hurry"], ["もちろん", "もちろん", "of course"], ["たぶん", "たぶん", "probably / maybe"]],
-  "grammar": {
-    "pattern": "おつかれさまでした",
-    "meaning": "Thank you for your hard work",
-    "example_jp": "きょうも　おつかれさまでした！",
-    "example_en": "Good work today!"
-  },
-  "practice": "Practise the meal phrases いただきます and ごちそうさまでした — these are required etiquette in Japan!",
-  "tip": "いただきます and ごちそうさまでした have no direct English translation. They express gratitude for the food and everyone who prepared it."
-}, {
-  "day": 49,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 7,
-  "title": "Greetings Review",
-  "intro": "Review all greetings and expressions from this week in context.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["おはようございます", "おはようございます", "good morning"], ["ありがとうございます", "ありがとうございます", "thank you"], ["すみません", "すみません", "excuse me"], ["はじめまして", "はじめまして", "nice to meet you"], ["よろしくおねがいします", "よろしくおねがいします", "pleased to meet you"]],
-  "grammar": {
-    "pattern": "はじめまして。〜です。よろしくおねがいします",
-    "meaning": "Full introduction pattern",
-    "example_jp": "はじめまして。マリアです。スペインからきました。よろしくおねがいします",
-    "example_en": "Nice to meet you. I'm Maria. I'm from Spain. Pleased to meet you"
-  },
-  "practice": "Write and memorise a complete self-introduction in Japanese (5-6 sentences).",
-  "tip": "Consistency is key! Practice your self-introduction until it flows naturally — you'll use it many times in Japan."
-}, {
-  "day": 50,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 8,
-  "title": "Topic Particle は",
-  "intro": "は marks the topic of the sentence. X は Y です = X is Y. This is the most fundamental sentence pattern.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["わたしは　がくせいです", "わたしは　がくせいです", "I am a student"], ["これは　ほんです", "これは　ほんです", "This is a book"], ["かれは　せんせいです", "かれは　せんせいです", "He is a teacher"], ["にほんは　くにです", "にほんは　くにです", "Japan is a country"], ["これは　なんですか", "これは　なんですか", "What is this?"]],
-  "grammar": {
-    "pattern": "X は Y です",
-    "meaning": "X is Y (X is the topic)",
-    "example_jp": "わたしは　にほんごの　がくせいです",
-    "example_en": "I am a student of Japanese"
-  },
-  "practice": "Make 5 sentences using XはYです about yourself and things around you.",
-  "tip": "は is pronounced 'wa' when used as a particle! It's spelled は (ha) but read as 'wa'. Classic Japanese quirk!"
-}, {
-  "day": 51,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 8,
-  "title": "Negative: じゃないです",
-  "intro": "X は Y じゃないです = X is not Y. The polite negative of です.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["わたしは　せんせいじゃないです", "わたしは　せんせいじゃないです", "I am not a teacher"], ["これは　ほんじゃないです", "これは　ほんじゃないです", "This is not a book"], ["かれは　がくせいじゃないです", "かれは　がくせいじゃないです", "He is not a student"], ["にほんごは　むずかしくないです", "にほんごは　むずかしくないです", "Japanese is not difficult"], ["あれは　くるまじゃないです", "あれは　くるまじゃないです", "That is not a car"]],
-  "grammar": {
-    "pattern": "X は Y じゃないです",
-    "meaning": "X is not Y",
-    "example_jp": "これは　コーヒーじゃないです。おちゃです",
-    "example_en": "This is not coffee. It is tea"
-  },
-  "practice": "Negate 5 sentences from yesterday's practice. Then try mixing positive and negative in one paragraph.",
-  "tip": "More formal version: ではありません (de wa arimasen). じゃないです is fine for most situations. ではありません for formal writing."
-}, {
-  "day": 52,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 8,
-  "title": "Questions with か",
-  "intro": "Adding か to the end of a statement makes it a yes/no question. そうです = That's right. ちがいます = That's wrong.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["がくせいですか", "がくせいですか", "Are you a student?"], ["はい、そうです", "はい、そうです", "Yes, that's right"], ["いいえ、ちがいます", "いいえ、ちがいます", "No, that's not right"], ["これは　なんですか", "これは　なんですか", "What is this?"], ["なんさいですか", "なんさいですか", "How old are you?"]],
-  "grammar": {
-    "pattern": "〜ですか",
-    "meaning": "Is it ~? / Are you ~?",
-    "example_jp": "にほんじんですか。いいえ、アメリカじんです",
-    "example_en": "Are you Japanese? No, I'm American"
-  },
-  "practice": "Practice Q&A: ask a partner (or yourself!) 5 questions using ですか and answer them.",
-  "tip": "In casual speech, か is often dropped and replaced by a rising intonation: がくせい？ (Are you a student?) — but です or ます must still be there in polite speech."
-}, {
-  "day": 53,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 8,
-  "title": "Particle も — also/too",
-  "intro": "も replaces は (or が/を) to mean 'also' or 'too'. Very simple and very useful.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["わたしも　がくせいです", "わたしも　がくせいです", "I am also a student"], ["これも　ほんです", "これも　ほんです", "This is also a book"], ["やまださんも　にほんじんです", "やまださんも　にほんじんです", "Yamada-san is also Japanese"], ["コーヒーも　おちゃも　すきです", "コーヒーも　おちゃも　すきです", "I like both coffee and tea"], ["わたしも！", "わたしも！", "Me too!"]],
-  "grammar": {
-    "pattern": "〜も〜です",
-    "meaning": "~ is also ~",
-    "example_jp": "かのじょも　いしゃです",
-    "example_en": "She is also a doctor"
-  },
-  "practice": "Make 3 sentences using も to connect two similar ideas or add 'me too' to a conversation.",
-  "tip": "Xも Yも = both X and Y. This is a great way to list things inclusively in Japanese!"
-}, {
-  "day": 54,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 8,
-  "title": "Occupations Vocabulary",
-  "intro": "Essential job and role vocabulary for introductions and conversations.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["がくせい", "がくせい", "student"], ["せんせい", "せんせい", "teacher"], ["かいしゃいん", "かいしゃいん", "office worker"], ["いしゃ", "いしゃ", "doctor"], ["エンジニア", "エンジニア", "engineer"]],
-  "grammar": {
-    "pattern": "〜を　しています",
-    "meaning": "I work as / I do ~",
-    "example_jp": "わたしは　エンジニアを　しています",
-    "example_en": "I work as an engineer"
-  },
-  "practice": "Learn 10 occupations. Can you describe what 5 different people do, using は and です?",
-  "tip": "〜をしています is more natural than just 〜です for jobs. かいしゃいん is a generic term for any company employee — very common in Japan!"
-}, {
-  "day": 55,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 8,
-  "title": "Nationalities & Countries",
-  "intro": "〜じん = person from ~. 〜ご = language of ~. にほん→にほんじん、にほんご.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["にほんじん", "にほんじん", "Japanese person"], ["アメリカじん", "アメリカじん", "American person"], ["イギリスじん", "イギリスじん", "British person"], ["ちゅうごくじん", "ちゅうごくじん", "Chinese person"], ["にほんご", "にほんご", "Japanese language"]],
-  "grammar": {
-    "pattern": "〜じんです",
-    "meaning": "I am ~ (nationality)",
-    "example_jp": "わたしは　アメリカじんです。えいごを　はなします",
-    "example_en": "I am American. I speak English"
-  },
-  "practice": "What is your nationality? What languages do you speak? Write 3 sentences.",
-  "tip": "The suffix じん means 'person from'. ご means 'language of'. So にほんご = Japanese language, ちゅうごくご = Chinese language!"
-}, {
-  "day": 56,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 8,
-  "title": "は Particle Review & Dialogue",
-  "intro": "Putting it all together: introductions using は, じゃないです, ですか, も.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["わたしのなまえは〜です", "わたしのなまえは〜です", "My name is ~"], ["どちらから　いらっしゃいましたか", "どちらから　いらっしゃいましたか", "Where are you from? (polite)"], ["おしごとは？", "おしごとは？", "What do you do? (casual)"], ["がくせいですか", "がくせいですか", "Are you a student?"], ["そうです！", "そうです！", "That's right!"]],
-  "grammar": {
-    "pattern": "はじめまして。わたしは〜です。〜からきました。よろしくおねがいします",
-    "meaning": "Standard self-introduction",
-    "example_jp": "はじめまして。アランです。アメリカからきました。エンジニアをしています。よろしくおねがいします",
-    "example_en": "Nice to meet you. I'm Alan. I'm from America. I'm an engineer. Pleased to meet you"
-  },
-  "practice": "Write and practise a full 5-line self-introduction. Then write a dialogue between two people meeting for the first time.",
-  "tip": "You've now learned the most important sentence pattern in Japanese: XはYです. Everything builds on this foundation!"
-}, {
-  "day": 57,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 9,
-  "title": "Subject Particle が",
-  "intro": "が marks the grammatical subject — often used to highlight NEW information or with certain verbs.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["だれが　きますか", "だれが　きますか", "Who is coming?"], ["なにが　すきですか", "なにが　すきですか", "What do you like?"], ["ねこが　います", "ねこが　います", "There is a cat"], ["あめが　ふっています", "あめが　ふっています", "It is raining"], ["わたしが　やります", "わたしが　やります", "I will do it (emphatic)"]],
-  "grammar": {
-    "pattern": "〜が　あります/います",
-    "meaning": "There is ~ (exists)",
-    "example_jp": "つくえの　うえに　ほんが　あります",
-    "example_en": "There is a book on the desk"
-  },
-  "practice": "Make 3 sentences with が for emphasis ('I am the one who...') and 3 with あります/います.",
-  "tip": "は vs が: は = topic (already known), が = subject (new info / focus). This is one of the trickiest distinctions in Japanese!"
-}, {
-  "day": 58,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 9,
-  "title": "Object Particle を",
-  "intro": "を marks the direct object — what receives the action of the verb.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["ほんを　よみます", "ほんを　よみます", "I read a book"], ["コーヒーを　のみます", "コーヒーを　のみます", "I drink coffee"], ["えいごを　べんきょうします", "えいごを　べんきょうします", "I study English"], ["おんがくを　ききます", "おんがくを　ききます", "I listen to music"], ["みちを　あるきます", "みちを　あるきます", "I walk along the road"]],
-  "grammar": {
-    "pattern": "〜を　Vます",
-    "meaning": "Do V to ~",
-    "example_jp": "まいあさ　にほんごを　べんきょうします",
-    "example_en": "I study Japanese every morning"
-  },
-  "practice": "Write 5 sentences about your daily habits using を + verb.",
-  "tip": "を is almost only used as the object particle — that makes it easy! When you see を, just know the word before it is being acted upon."
-}, {
-  "day": 59,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 9,
-  "title": "Possessive Particle の",
-  "intro": "の connects nouns: X の Y = Y of X, or X's Y. Also used to nominalise verbs.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["わたしの　ほん", "わたしの　ほん", "my book"], ["にほんの　たべもの", "にほんの　たべもの", "Japanese food"], ["かれの　なまえ", "かれの　なまえ", "his name"], ["がっこうの　せんせい", "がっこうの　せんせい", "school teacher"], ["どこの　くにですか", "どこの　くにですか", "What country are you from?"]],
-  "grammar": {
-    "pattern": "X の Y",
-    "meaning": "Y of X / X's Y",
-    "example_jp": "これは　わたしの　にほんごの　じしょです",
-    "example_en": "This is my Japanese dictionary"
-  },
-  "practice": "Practice chaining の: 'my school's teacher', 'Japan's food', 'your friend's name'.",
-  "tip": "の can chain multiple nouns: 日本の大学の先生 (a teacher at a Japanese university). Just keep adding の!"
-}, {
-  "day": 60,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 9,
-  "title": "Combining は・が・を・の",
-  "intro": "Practice combining the 4 particles learned so far in complex sentences.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["わたしは　にほんごの　ほんを　よみます", "わたしは　にほんごの　ほんを　よみます", "I read a Japanese book"], ["あなたの　せんせいは　だれですか", "あなたの　せんせいは　だれですか", "Who is your teacher?"], ["わたしが　このほんを　かいました", "わたしが　このほんを　かいました", "I bought this book (emphatic)"], ["かれのくるまは　あかいです", "かれのくるまは　あかいです", "His car is red"], ["にほんのたべものが　すきです", "にほんのたべものが　すきです", "I like Japanese food"]],
-  "grammar": {
-    "pattern": "XはYのZをVます",
-    "meaning": "X does V to Z of Y",
-    "example_jp": "わたしは　にほんの　うたを　ききます",
-    "example_en": "I listen to Japanese songs"
-  },
-  "practice": "Write 3 complex sentences using 3+ particles each.",
-  "tip": "Particles are like labels on words. Once you understand each label's meaning, you can stack them to build any sentence!"
-}, {
-  "day": 61,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 9,
-  "title": "Demonstratives: これ・それ・あれ",
-  "intro": "これ = this (near me), それ = that (near you), あれ = that (far from both).",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["これは　なんですか", "これは　なんですか", "What is this?"], ["それは　わたしの　かさです", "それは　わたしの　かさです", "That is my umbrella"], ["あれは　ふじさんです", "あれは　ふじさんです", "That (over there) is Mt. Fuji"], ["この　ほんは　おもしろいです", "この　ほんは　おもしろいです", "This book is interesting"], ["どれが　あなたのですか", "どれが　あなたのですか", "Which one is yours?"]],
-  "grammar": {
-    "pattern": "これ/それ/あれ は 〜です",
-    "meaning": "This/That/That over there is ~",
-    "example_jp": "あれは　なんですか？　あれは　とうきょうタワーです",
-    "example_en": "What is that? That is Tokyo Tower"
-  },
-  "practice": "Point at 5 objects near and far and describe them using これ/それ/あれ.",
-  "tip": "これ/それ/あれ stand alone as pronouns. この/その/あの are used BEFORE a noun: このほん (this book), そのかばん (that bag)."
-}, {
-  "day": 62,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 9,
-  "title": "Location Words",
-  "intro": "Spatial vocabulary: above, below, left, right, front, back, inside, outside.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["うえ", "うえ", "above / on top"], ["した", "した", "below / under"], ["みぎ", "みぎ", "right"], ["ひだり", "ひだり", "left"], ["まえ", "まえ", "front / before"]],
-  "grammar": {
-    "pattern": "〜の　うえに　あります",
-    "meaning": "It is on top of ~",
-    "example_jp": "つくえの　したに　ねこが　います",
-    "example_en": "There is a cat under the desk"
-  },
-  "practice": "Describe where 5 objects in your room are using location words + あります/います.",
-  "tip": "Location words always follow の: つくえのうえ (on the desk), いすのした (under the chair), ドアのまえ (in front of the door)."
-}, {
-  "day": 63,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 9,
-  "title": "Particles Review & Reading",
-  "intro": "Review は、が、を、の plus demonstratives and location words. Read a short passage.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["わたしのへやに　つくえが　あります", "わたしのへやに　つくえが　あります", "In my room there is a desk"], ["つくえのうえに　ほんと　ペンが　あります", "つくえのうえに　ほんと　ペンが　あります", "On the desk there are books and a pen"], ["まどのそとは　にわです", "まどのそとは　にわです", "Outside the window is a garden"], ["このほんは　おもしろいです", "このほんは　おもしろいです", "This book is interesting"], ["あなたのほんは　どこですか", "あなたのほんは　どこですか", "Where is your book?"]],
-  "grammar": {
-    "pattern": "〜のそばに　〜があります",
-    "meaning": "Near ~, there is ~",
-    "example_jp": "えきのそばに　コンビニが　あります",
-    "example_en": "Near the station there is a convenience store"
-  },
-  "practice": "Write a 5-sentence paragraph describing your room or workspace using the particles learned.",
-  "tip": "Reading your own writing aloud is one of the best ways to internalise Japanese grammar patterns!"
-}, {
-  "day": 64,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 10,
-  "title": "Location Particle に (existence)",
-  "intro": "に marks LOCATION of existence with あります/います.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["えきに　います", "えきに　います", "(I) am at the station"], ["つくえのうえに　あります", "つくえのうえに　あります", "It is on the desk"], ["にわに　ねこが　います", "にわに　ねこが　います", "There is a cat in the garden"], ["どこに　ありますか", "どこに　ありますか", "Where is it?"], ["がっこうに　せんせいが　います", "がっこうに　せんせいが　います", "There is a teacher at school"]],
-  "grammar": {
-    "pattern": "〜に　あります/います",
-    "meaning": "(thing) exists at/in ~",
-    "example_jp": "れいぞうこに　たまごが　あります",
-    "example_en": "There are eggs in the fridge"
-  },
-  "practice": "Practice: say where 5 objects are in your home or school using に + あります/います.",
-  "tip": "あります = for inanimate things. います = for living things (people, animals). Never mix them up!"
-}, {
-  "day": 65,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 10,
-  "title": "Direction Particle に (movement)",
-  "intro": "に also marks the DESTINATION of movement: 〜に　いきます (go to ~).",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["がっこうに　いきます", "がっこうに　いきます", "I go to school"], ["えきに　きます", "えきに　きます", "I come to the station"], ["うちに　かえります", "うちに　かえります", "I return home"], ["にほんに　いきたい", "にほんに　いきたい", "I want to go to Japan"], ["どこに　いきますか", "どこに　いきますか", "Where are you going?"]],
-  "grammar": {
-    "pattern": "〜に　いきます",
-    "meaning": "go to ~",
-    "example_jp": "あした　とうきょうに　いきます",
-    "example_en": "Tomorrow I will go to Tokyo"
-  },
-  "practice": "Make sentences about where you go: school, supermarket, hospital, Japan, etc.",
-  "tip": "に for destination vs で for location of action: がっこうに　いきます (go TO school) vs がっこうで　べんきょうします (study AT school)."
-}, {
-  "day": 66,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 10,
-  "title": "Location of Action: で",
-  "intro": "で marks where an ACTION takes place (not just where something exists).",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["がっこうで　べんきょうします", "がっこうで　べんきょうします", "I study at school"], ["レストランで　たべます", "レストランで　たべます", "I eat at a restaurant"], ["こうえんで　あそびます", "こうえんで　あそびます", "I play in the park"], ["えきで　まちます", "えきで　まちます", "I wait at the station"], ["どこで　はたらいていますか", "どこで　はたらいていますか", "Where do you work?"]],
-  "grammar": {
-    "pattern": "〜で　Vます",
-    "meaning": "do V at/in ~",
-    "example_jp": "としょかんで　ほんを　よみます",
-    "example_en": "I read books at the library"
-  },
-  "practice": "Describe your day using で: where you eat, study, work, exercise.",
-  "tip": "KEY DISTINCTION: に marks LOCATION of existence (ここにあります) while で marks LOCATION OF ACTION (ここでたべます). Many learners mix these up!"
-}, {
-  "day": 67,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 10,
-  "title": "Means/Method: で",
-  "intro": "で also marks the MEANS by which something is done — transport, tools, language.",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["でんしゃで　いきます", "でんしゃで　いきます", "I go by train"], ["えいごで　はなします", "えいごで　はなします", "I speak in English"], ["はしで　たべます", "はしで　たべます", "I eat with chopsticks"], ["くるまで　きました", "くるまで　きました", "I came by car"], ["なにで　きましたか", "なにで　きましたか", "How did you come (by what means)?"]],
-  "grammar": {
-    "pattern": "〜で　いきます",
-    "meaning": "go by ~ (transport)",
-    "example_jp": "じてんしゃで　がっこうに　いきます",
-    "example_en": "I go to school by bicycle"
-  },
-  "practice": "How do you get to school/work? Write 3 sentences using で + transport.",
-  "tip": "Same particle で, two uses: location of action AND means/method. Context makes it clear which meaning applies."
-}, {
-  "day": 68,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 10,
-  "title": "Together with: と・や",
-  "intro": "と = and (exhaustive list / together with). や = and (partial list, etc.).",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["やまださんと　いきます", "やまださんと　いきます", "I go with Yamada-san"], ["ほんと　ペンが　あります", "ほんと　ペンが　あります", "There is a book and a pen"], ["すしや　てんぷらなど", "すしや　てんぷらなど", "sushi, tempura, etc."], ["ともだちと　あそびます", "ともだちと　あそびます", "I play/hang out with a friend"], ["なにと　なにが　すきですか", "なにと　なにが　すきですか", "What (things) do you like?"]],
-  "grammar": {
-    "pattern": "〜と　〜が　あります",
-    "meaning": "There is ~ and ~",
-    "example_jp": "かばんの　なかに　さいふと　けいたいが　あります",
-    "example_en": "In my bag there is a wallet and a phone"
-  },
-  "practice": "List the things in your bag or room using と and や.",
-  "tip": "と = complete list (A and B, that's all). や = partial list (A and B and others). Use や when there are more items you aren't listing!"
-}, {
-  "day": 69,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 10,
-  "title": "From/To: から・まで",
-  "intro": "から = from (place, time, reason). まで = until/to (place, time).",
-  "type": "particles",
-  "chars": [],
-  "vocab": [["くじから　ごじまで", "くじから　ごじまで", "from 9 to 5"], ["えきから　あるきます", "えきから　あるきます", "I walk from the station"], ["とうきょうから　おおさかまで", "とうきょうから　おおさかまで", "from Tokyo to Osaka"], ["いつから　べんきょうしていますか", "いつから　べんきょうしていますか", "Since when have you been studying?"], ["〜だから", "〜だから", "because ~ (reason)"]],
-  "grammar": {
-    "pattern": "〜から〜まで",
-    "meaning": "from ~ to/until ~",
-    "example_jp": "げつようびから　きんようびまで　はたらきます",
-    "example_en": "I work from Monday to Friday"
-  },
-  "practice": "Describe your schedule: from what time to what time do you study, work, sleep?",
-  "tip": "から also introduces reasons (だから = therefore, そうだから = because that's how it is). This links to grammar in Phase 6!"
-}, {
-  "day": 70,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 10,
-  "title": "Particles Review",
-  "intro": "Full review of に、で、と、から、まで in combined sentences.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["でんしゃで　えきから　うちまで　かえります", "でんしゃで　えきから　うちまで　かえります", "I go home from the station to my house by train"], ["ともだちと　こうえんで　あそびます", "ともだちと　こうえんで　あそびます", "I play in the park with a friend"], ["かいしゃは　くじから　ごじまでです", "かいしゃは　くじから　ごじまでです", "Work is from 9 to 5"], ["にほんに　いきたいです", "にほんに　いきたいです", "I want to go to Japan"], ["どこで　ひるごはんを　たべますか", "どこで　ひるごはんを　たべますか", "Where do you eat lunch?"]],
-  "grammar": {
-    "pattern": "〜で〜から〜まで〜に〜います",
-    "meaning": "Complex sentence with multiple particles",
-    "example_jp": "バスで　えきから　びょういんまで　いきます",
-    "example_en": "I go from the station to the hospital by bus"
-  },
-  "practice": "Write 5 complex sentences each using 3 or more particles.",
-  "tip": "You now know the core particles! は、が、を、の、に、で、と、も、から、まで — these cover 90% of everyday Japanese."
-}, {
-  "day": 71,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 11,
-  "title": "い-Adjectives: Big, Small, New, Old",
-  "intro": "い-adjectives end in い and directly modify nouns. They also conjugate.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["おおきい　いえ", "おおきい　いえ", "big house"], ["ちいさい　ねこ", "ちいさい　ねこ", "small cat"], ["あたらしい　くるま", "あたらしい　くるま", "new car"], ["ふるい　ほん", "ふるい　ほん", "old book"], ["たかい　やま", "たかい　やま", "tall mountain / expensive"]],
-  "grammar": {
-    "pattern": "い-adj + noun",
-    "meaning": "adjective modifies noun directly",
-    "example_jp": "あたらしい　スマートフォンが　ほしいです",
-    "example_en": "I want a new smartphone"
-  },
-  "practice": "Describe 5 objects using い-adjectives: size, age, price, temperature.",
-  "tip": "い-adjectives are easy to use before nouns! Just put them directly in front: おおきい＋いえ = おおきいいえ. No の needed (unlike な-adjectives)."
-}, {
-  "day": 72,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 11,
-  "title": "More い-Adjectives",
-  "intro": "Hot, cold, delicious, scary, fun — emotions and sensations.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["あついです", "あついです", "it is hot"], ["さむいです", "さむいです", "it is cold"], ["おいしいです", "おいしいです", "it is delicious"], ["こわいです", "こわいです", "it is scary"], ["たのしいです", "たのしいです", "it is fun"]],
-  "grammar": {
-    "pattern": "〜は　い-adjです",
-    "meaning": "~ is [adjective]",
-    "example_jp": "きょうは　あついですね！",
-    "example_en": "It's hot today, isn't it!"
-  },
-  "practice": "Describe today's weather, yesterday's dinner, and a recent activity using い-adjectives.",
-  "tip": "ね at the end seeks agreement (like 'isn't it?'). よ asserts a fact. This is just like Day 71 taught — these particles add tone!"
-}, {
-  "day": 73,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 11,
-  "title": "い-Adj Conjugation: Negative & Past",
-  "intro": "い-adjectives conjugate! Negative: 〜くない。Past: 〜かった。Past negative: 〜くなかった。",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["あつくないです", "あつくないです", "it is not hot"], ["たかくないです", "たかくないです", "it is not expensive"], ["おもしろかったです", "おもしろかったです", "it was interesting"], ["さむくなかったです", "さむくなかったです", "it was not cold"], ["よかったです", "よかったです", "it was good (irregular: いい→よかった)"]],
-  "grammar": {
-    "pattern": "い-adj → 〜くないです / 〜かったです",
-    "meaning": "not ~ / was ~",
-    "example_jp": "きのうは　そんなに　さむくなかったです",
-    "example_en": "Yesterday it wasn't that cold"
-  },
-  "practice": "Conjugate 5 adjectives in all 4 forms: present, negative, past, past negative.",
-  "tip": "Special case! いい (good) is irregular: past = よかった, not いかった. This is one of the most common adjectives — memorise it!"
-}, {
-  "day": 74,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 11,
-  "title": "な-Adjectives",
-  "intro": "な-adjectives need な before nouns and だ/です in predicates. They DON'T conjugate with the adjective stem (the noun does the work).",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["しずかな　まち", "しずかな　まち", "quiet town"], ["きれいな　はな", "きれいな　はな", "pretty flower"], ["げんきな　こども", "げんきな　こども", "energetic child"], ["べんりな　アプリ", "べんりな　アプリ", "convenient app"], ["ゆうめいな　ひと", "ゆうめいな　ひと", "famous person"]],
-  "grammar": {
-    "pattern": "な-adj + な + noun / な-adj + です",
-    "meaning": "na-adjective modifying noun",
-    "example_jp": "にほんごは　たいせつな　げんごです",
-    "example_en": "Japanese is an important language"
-  },
-  "practice": "Practice: describe your town, a person you know, and your phone using な-adjectives.",
-  "tip": "な-adjectives look like nouns! In a sentence: しずかです (it is quiet). Before a noun: しずかな まち (quiet town). Don't forget the な!"
-}, {
-  "day": 75,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 11,
-  "title": "Comparing: 〜より〜のほうが",
-  "intro": "AはBよりXです = A is more X than B. BよりAのほうがXです = A is more X than B (emphasising A).",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["とうきょうは　おおさかより　おおきいです", "とうきょうは　おおさかより　おおきいです", "Tokyo is bigger than Osaka"], ["でんしゃは　バスより　はやいです", "でんしゃは　バスより　はやいです", "Trains are faster than buses"], ["このほうが　すきです", "このほうが　すきです", "I prefer this one"], ["どちらが　すきですか", "どちらが　すきですか", "Which do you prefer?"], ["いちばん　すきです", "いちばん　すきです", "I like it the most"]],
-  "grammar": {
-    "pattern": "AはBより〜です",
-    "meaning": "A is more ~ than B",
-    "example_jp": "なつは　ふゆより　あついです",
-    "example_en": "Summer is hotter than winter"
-  },
-  "practice": "Make 5 comparisons: cities, seasons, foods, transport methods.",
-  "tip": "いちばん = the most (superlative). クラスで　いちばん　はやい (fastest in the class). Simple and powerful!"
-}, {
-  "day": 76,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 11,
-  "title": "Adjective Review",
-  "intro": "Comprehensive review of い-adjectives and な-adjectives.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["おおきくて　あたらしいです", "おおきくて　あたらしいです", "big and new (i+i adj)"], ["しずかで　きれいです", "しずかで　きれいです", "quiet and beautiful (na+na adj)"], ["やすくて　おいしいです", "やすくて　おいしいです", "cheap and delicious"], ["ゆうめいで　べんりです", "ゆうめいで　べんりです", "famous and convenient"], ["あかくて　ちいさいです", "あかくて　ちいさいです", "red and small"]],
-  "grammar": {
-    "pattern": "adj1 + て/で + adj2",
-    "meaning": "adj1 and adj2 (linking adjectives)",
-    "example_jp": "このレストランは　やすくて　おいしいです",
-    "example_en": "This restaurant is cheap and delicious"
-  },
-  "practice": "Describe 5 things using 2 adjectives each, connected with て/で.",
-  "tip": "To connect い-adjectives: 〜くて。To connect な-adjectives: 〜で。Mixed: first adj follows its own rule, second adj ends normally."
-}, {
-  "day": 77,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 11,
-  "title": "Adjective Review & Short Descriptions",
-  "intro": "Writing short descriptions using all adjectives and particles learned.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["わたしのまちは　しずかで　きれいです", "わたしのまちは　しずかで　きれいです", "My town is quiet and beautiful"], ["にほんごは　むずかしいですが　おもしろいです", "にほんごは　むずかしいですが　おもしろいです", "Japanese is difficult but interesting"], ["あのひとは　せがたかくて　かっこいいです", "あのひとは　せがたかくて　かっこいいです", "That person is tall and good-looking"], ["このまちは　にぎやかで　べんりです", "このまちは　にぎやかで　べんりです", "This town is lively and convenient"], ["おすしは　おいしいですが　たかいです", "おすしは　おいしいですが　たかいです", "Sushi is delicious but expensive"]],
-  "grammar": {
-    "pattern": "〜は〜ですが、〜です",
-    "meaning": "~ is ~, but ~",
-    "example_jp": "にほんごは　むずかしいですが、たのしいです",
-    "example_en": "Japanese is difficult, but it's fun"
-  },
-  "practice": "Write a description of: your home, your city, your favourite food — using at least 2 adjectives each.",
-  "tip": "が after a clause means 'but' — contrasting two ideas. わかりますが、むずかしいです (I understand it, but it's difficult)."
-}, {
-  "day": 78,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 12,
-  "title": "Verbs: ます Form Introduction",
-  "intro": "Japanese verbs end in ます in polite form. Two main groups: る-verbs and う-verbs.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["たべます", "たべます", "eat (polite)"], ["のみます", "のみます", "drink (polite)"], ["いきます", "いきます", "go (polite)"], ["きます", "きます", "come (polite)"], ["します", "します", "do (polite)"]],
-  "grammar": {
-    "pattern": "〜ます",
-    "meaning": "polite present/future verb",
-    "example_jp": "まいにち　にほんごを　べんきょうします",
-    "example_en": "I study Japanese every day"
-  },
-  "practice": "Memorise these 10 core verbs in ます form: たべます、のみます、いきます、きます、します、みます、ききます、よみます、かきます、はなします.",
-  "tip": "ます form is the standard polite level for daily conversation. Think of it as the 'default' form you'll use with anyone you don't know well."
-}, {
-  "day": 79,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 12,
-  "title": "Common Verbs in ます Form",
-  "intro": "Expanding the verb vocabulary with essential daily verbs.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["おきます", "おきます", "get up / wake up"], ["ねます", "ねます", "sleep / go to bed"], ["たちます", "たちます", "stand up"], ["すわります", "すわります", "sit down"], ["あるきます", "あるきます", "walk"]],
-  "grammar": {
-    "pattern": "なんじに　〜ますか",
-    "meaning": "At what time do you ~?",
-    "example_jp": "なんじに　おきますか？　ろくじに　おきます",
-    "example_en": "What time do you wake up? I wake up at 6"
-  },
-  "practice": "Describe your morning routine using 5 different verbs in ます form.",
-  "tip": "に after a time word marks the specific time: ろくじに おきます (wake up AT 6). Without に: まいあさ おきます (wake up every morning — no specific time)."
-}, {
-  "day": 80,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 12,
-  "title": "Negative: 〜ません",
-  "intro": "〜ません is the polite negative. Add it instead of 〜ます.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["たべません", "たべません", "don't eat"], ["いきません", "いきません", "don't go"], ["わかりません", "わかりません", "don't understand"], ["にほんごを　はなしません", "にほんごを　はなしません", "don't speak Japanese"], ["テレビを　みません", "テレビを　みません", "don't watch TV"]],
-  "grammar": {
-    "pattern": "〜ません",
-    "meaning": "don't / won't ~ (polite negative)",
-    "example_jp": "わたしは　お酒を　のみません",
-    "example_en": "I don't drink alcohol"
-  },
-  "practice": "Negate 5 sentences from yesterday's practice. Then write 3 things you don't do.",
-  "tip": "Don't confuse ません (negative present) with ませんでした (negative past). The でした marks it as past tense!"
-}, {
-  "day": 81,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 12,
-  "title": "Past: 〜ました",
-  "intro": "〜ました is the polite past tense. Negative past: 〜ませんでした.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["たべました", "たべました", "ate"], ["いきました", "いきました", "went"], ["べんきょうしました", "べんきょうしました", "studied"], ["みませんでした", "みませんでした", "didn't watch"], ["はなしました", "はなしました", "spoke"]],
-  "grammar": {
-    "pattern": "〜ました / 〜ませんでした",
-    "meaning": "did ~ / didn't ~",
-    "example_jp": "きのう　えいがを　みました",
-    "example_en": "Yesterday I watched a movie"
-  },
-  "practice": "Describe yesterday: 3 things you did (〜ました) and 2 you didn't do (〜ませんでした).",
-  "tip": "The key: ます→ました (did), ません→ませんでした (didn't). The pattern is perfectly regular!"
-}, {
-  "day": 82,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 12,
-  "title": "Verb Patterns with Frequency",
-  "intro": "Frequency adverbs: まいにち (every day), よく (often), ときどき (sometimes), あまり〜ない (not much).",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["まいにち　べんきょうします", "まいにち　べんきょうします", "study every day"], ["よく　えいがを　みます", "よく　えいがを　みます", "often watch movies"], ["ときどき　そとで　たべます", "ときどき　そとで　たべます", "sometimes eat out"], ["あまり　テレビを　みません", "あまり　テレビを　みません", "don't watch TV much"], ["ぜんぜん　たべません", "ぜんぜん　たべません", "don't eat at all"]],
-  "grammar": {
-    "pattern": "あまり〜ません",
-    "meaning": "don't ~ very much",
-    "example_jp": "あまり　にくを　たべません",
-    "example_en": "I don't eat much meat"
-  },
-  "practice": "Write about your habits using frequency words: まいにち、よく、ときどき、あまり〜ない、ぜんぜん〜ない.",
-  "tip": "あまり and ぜんぜん ALWAYS go with negative verbs (ません). Never: あまり　たべます. Correct: あまり　たべません."
-}, {
-  "day": 83,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 12,
-  "title": "Core Verb Vocabulary List",
-  "intro": "Vocabulary building: 20 essential verbs for N5.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["みる", "みる", "see / watch"], ["きく", "きく", "listen / ask"], ["よむ", "よむ", "read"], ["かく", "かく", "write"], ["かう", "かう", "buy"]],
-  "grammar": {
-    "pattern": "〜を　Vます",
-    "meaning": "do V to ~",
-    "example_jp": "まいにち　にほんごを　べんきょうして、おんがくを　きいて、ほんを　よみます",
-    "example_en": "Every day I study Japanese, listen to music, and read books"
-  },
-  "practice": "Make sentences with: みます、かいます、かきます、はなします、おしえます、おぼえます、わすれます、つかいます.",
-  "tip": "Tip: みる、きく、よむ、かく、はなす are the 5 communication verbs. If you can do these in Japanese, you can learn anything!"
-}, {
-  "day": 84,
-  "phaseNum": 3,
-  "phaseName": "Foundations",
-  "week": 12,
-  "title": "Foundations Full Review",
-  "intro": "Review all of Phase 3 with JLPT-style practice questions.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["なんじに　がっこうに　いきますか", "なんじに　がっこうに　いきますか", "What time do you go to school?"], ["きのう　なにを　しましたか", "きのう　なにを　しましたか", "What did you do yesterday?"], ["このまちは　どんなまちですか", "このまちは　どんなまちですか", "What kind of town is this?"], ["〜は　どこに　ありますか", "〜は　どこに　ありますか", "Where is ~?"], ["なんようびが　すきですか", "なんようびが　すきですか", "What day of the week do you like?"]],
-  "grammar": {
-    "pattern": "〜は　どんな〜ですか",
-    "meaning": "What kind of ~ is ~?",
-    "example_jp": "にほんは　どんなくにですか",
-    "example_en": "What kind of country is Japan?"
-  },
-  "practice": "Answer all 5 questions above in complete Japanese sentences. Then review any areas you found difficult.",
-  "tip": "Congratulations on completing Phase 3! You now have the foundation to hold basic conversations in Japanese. Phase 4 builds vocabulary!"
-}, {
-  "day": 85,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 13,
-  "title": "Family: My Own Family (Humble)",
-  "intro": "In Japanese, you use humble words for YOUR family and respectful words for others' families. Today: your own.",
-  "type": [["ちち", "my father"], ["はは", "my mother"], ["あに", "my older brother"], ["あね", "my older sister"], ["おとうと", "my younger brother"]],
-  "chars": [["ちち", "my father"], ["はは", "my mother"], ["あに", "my older brother"], ["あね", "my older sister"], ["おとうと", "my younger brother"]],
-  "vocab": [["いもうと", "いもうと", "my younger sister"], ["かぞく", "かぞく", "family"], ["りょうしん", "りょうしん", "both parents"], ["きょうだい", "きょうだい", "siblings"], ["かぞくは　なんにんですか", "かぞくは　なんにんですか", "How many people are in your family?"]],
-  "grammar": {
-    "pattern": "かぞくは　〜にんです",
-    "meaning": "My family has ~ people",
-    "example_jp": "かぞくは　よにんです。ちちとはははとあにとわたしです",
-    "example_en": "My family has 4 people: father, mother, older brother, and me"
-  },
-  "practice": "Describe your family in Japanese: how many people, who they are, what they do.",
-  "tip": "For YOUR family: ちち、はは、あに、あね (humble). For OTHERS' families: おとうさん、おかあさん、おにいさん、おねえさん (respectful). Never mix them up!"
-}, {
-  "day": 86,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 13,
-  "title": "Family: Others' Families (Respectful)",
-  "intro": "When talking about someone else's family, use honorific forms.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["おとうさん", "someone's father"], ["おかあさん", "someone's mother"], ["おにいさん", "someone's older brother"], ["おねえさん", "someone's older sister"], ["おこさん", "someone's child"]],
-  "grammar": [["ごかぞく", "ごかぞく", "your/their family"], ["ごきょうだい", "ごきょうだい", "your/their siblings"], ["おばあさん", "おばあさん", "someone's grandmother"], ["おじいさん", "おじいさん", "someone's grandfather"], ["ごりょうしん", "ごりょうしん", "your parents"]],
-  "practice": {
-    "pattern": "おとうさんは　おげんきですか",
-    "meaning": "Is your father well?",
-    "example_jp": "ごかぞくは　なんにんですか",
-    "example_en": "How many people are in your family?"
-  },
-  "tip": "Practice the humble/respectful distinction: describe YOUR family, then ask about SOMEONE ELSE's family."
-}, {
-  "day": 87,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 13,
-  "title": "Extended Family",
-  "intro": "Grandparents, aunts, uncles, cousins — the full family tree.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["そふ", "my grandfather"], ["そぼ", "my grandmother"], ["おじ", "my uncle"], ["おば", "my aunt"], ["いとこ", "cousin"]],
-  "grammar": [["おじいさん", "おじいさん", "someone's grandfather"], ["おばあさん", "おばあさん", "someone's grandmother"], ["まご", "まご", "grandchild"], ["おい", "おい", "nephew"], ["めい", "めい", "niece"]],
-  "practice": {
-    "pattern": "〜の　〜です",
-    "meaning": "~ 's ~",
-    "example_jp": "これは　そぼの　しゃしんです",
-    "example_en": "This is a photo of my grandmother"
-  },
-  "tip": "Draw a family tree and label each person with their Japanese name (humble forms for your family)."
-}, {
-  "day": 88,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 13,
-  "title": "Family Conversations",
-  "intro": "Putting family vocabulary into natural dialogue.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [],
-  "grammar": [["かぞくの　しゃしんを　みせてください", "かぞくの　しゃしんを　みせてください", "Please show me a photo of your family"], ["なんにんきょうだいですか", "なんにんきょうだいですか", "How many siblings do you have?"], ["ひとりっこです", "ひとりっこです", "I'm an only child"], ["〜さいです", "〜さいです", "(person) is ~ years old"], ["かかがにほんじんです", "かかがにほんじんです", "My mother is Japanese"]],
-  "practice": {
-    "pattern": "なんにんきょうだいですか",
-    "meaning": "How many siblings do you have?",
-    "example_jp": "ふたりきょうだいです。あにがひとりいます",
-    "example_en": "I have one sibling — an older brother"
-  },
-  "tip": "Write a paragraph about your family: size, ages, occupations, and any interesting details."
-}, {
-  "day": 89,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 13,
-  "title": "People Words",
-  "intro": "Words for describing and talking about people.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["ひと", "person"], ["おとこのひと", "man"], ["おんなのひと", "woman"], ["こども", "child"], ["おとな", "adult"]],
-  "grammar": [["わかもの", "わかもの", "young person"], ["おじさん", "おじさん", "middle-aged man / uncle"], ["おばさん", "おばさん", "middle-aged woman / aunt"], ["あかちゃん", "あかちゃん", "baby"], ["ともだち", "ともだち", "friend"]],
-  "practice": {
-    "pattern": "どんなひとですか",
-    "meaning": "What kind of person is ~?",
-    "example_jp": "かれは　やさしくて　おもしろいひとです",
-    "example_en": "He is a kind and interesting person"
-  },
-  "tip": "Describe 3 people you know using adjectives + ひとです."
-}, {
-  "day": 90,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 13,
-  "title": "Relationships",
-  "intro": "Words for different types of relationships.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["ともだち", "friend"], ["しりあい", "acquaintance"], ["クラスメート", "classmate"], ["どうりょう", "colleague"], ["じょうし", "boss"]],
-  "grammar": [["せんぱい", "せんぱい", "senior (at school/work)"], ["こうはい", "こうはい", "junior (at school/work)"], ["かれし", "かれし", "boyfriend"], ["かのじょ", "かのじょ", "girlfriend / she"], ["けっこんしています", "けっこんしています", "married"]],
-  "practice": {
-    "pattern": "〜は　わたしの　〜です",
-    "meaning": "~ is my ~",
-    "example_jp": "たなかさんは　わたしの　どうりょうです",
-    "example_en": "Tanaka-san is my colleague"
-  },
-  "tip": "Introduce 3 people in your life using relationship words."
-}, {
-  "day": 91,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 13,
-  "title": "Family Review",
-  "intro": "Consolidate all family vocabulary with a writing and speaking exercise.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [],
-  "grammar": [["かぞくしょうかい", "かぞくしょうかい", "family introduction"], ["ちちは　かいしゃいんです", "ちちは　かいしゃいんです", "My father is an office worker"], ["はははりょうりが　じょうずです", "はははりょうりが　じょうずです", "My mother is good at cooking"], ["あにはだいがくせいです", "あにはだいがくせいです", "My older brother is a university student"], ["かぞくがだいすきです", "かぞくがだいすきです", "I love my family"]],
-  "practice": {
-    "pattern": "〜は〜で、〜が　じょうずです",
-    "meaning": "~ is a ~ and is good at ~",
-    "example_jp": "ははは　せんせいで、えいごが　じょうずです",
-    "example_en": "My mother is a teacher and is good at English"
-  },
-  "tip": "Write a 5-sentence paragraph introducing your family to a Japanese friend."
-}, {
-  "day": 92,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "Head & Face",
-  "intro": "Body part vocabulary — essential for healthcare and descriptions.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["あたま", "head"], ["かお", "face"], ["め", "eye/eyes"], ["はな", "nose"], ["くち", "mouth"]],
-  "grammar": [["みみ", "みみ", "ear/ears"], ["は", "は", "tooth/teeth"], ["くびれ", "くち", "neck"], ["まゆげ", "まゆげ", "eyebrow"], ["まつげ", "まつげ", "eyelash"]],
-  "practice": {
-    "pattern": "〜が　いたいです",
-    "meaning": "~ hurts / I have a ~ ache",
-    "example_jp": "あたまが　いたいです",
-    "example_en": "I have a headache"
-  },
-  "tip": "Point to and say each body part. Practice: 'My _ hurts' for 5 body parts."
-}, {
-  "day": 93,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "Arms & Hands",
-  "intro": "Upper body parts for descriptions and medical conversations.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["かた", "shoulder"], ["うで", "arm"], ["ひじ", "elbow"], ["て", "hand"], ["ゆび", "finger"]],
-  "grammar": [["てくび", "てくび", "wrist"], ["つめ", "つめ", "nail/claw"], ["こぶし", "こぶし", "fist"], ["てのひら", "てのひら", "palm"], ["おやゆび", "おやゆび", "thumb"]],
-  "practice": {
-    "pattern": "〜をVてください",
-    "meaning": "Please do V with your ~",
-    "example_jp": "てを　あげてください",
-    "example_en": "Please raise your hand"
-  },
-  "tip": "Practice giving instructions using body parts: raise your hand, open your mouth, etc."
-}, {
-  "day": 94,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "Legs & Lower Body",
-  "intro": "Lower body vocabulary.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["むね", "chest"], ["おなか", "stomach/belly"], ["せなか", "back"], ["こし", "lower back/hip"], ["あし", "leg/foot"]],
-  "grammar": [["ひざ", "ひざ", "knee"], ["くるぶし", "くるぶし", "ankle"], ["かかと", "かかと", "heel"], ["つまさき", "つまさき", "toes/tip of foot"], ["そく", "そく", "foot (counter: 〜そく for footwear)"]],
-  "practice": {
-    "pattern": "〜のちょうしは　どうですか",
-    "meaning": "How is your ~ doing?",
-    "example_jp": "おなかの　ちょうしは　どうですか",
-    "example_en": "How is your stomach?"
-  },
-  "tip": "Describe any aches or pains you have using body part + がいたいです."
-}, {
-  "day": 95,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "Body + Adjectives",
-  "intro": "Describing physical appearance using body parts and adjectives.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [],
-  "grammar": [["せがたかい", "せがたかい", "tall (height)"], ["せがひくい", "せがひくい", "short (height)"], ["かみがながい", "かみがながい", "long hair"], ["めがおおきい", "めがおおきい", "big eyes"], ["がっしりした", "がっしりした", "stocky/sturdy build"]],
-  "practice": {
-    "pattern": "〜が〜です",
-    "meaning": "(person's) ~ is ~",
-    "example_jp": "かのじょは　かみが　ながくて　めが　おおきいです",
-    "example_en": "She has long hair and big eyes"
-  },
-  "tip": "Describe yourself or someone you know: height, hair, eyes, build."
-}, {
-  "day": 96,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "At the Doctor",
-  "intro": "Medical vocabulary for describing symptoms and seeing a doctor.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["びょうき", "illness"], ["くすり", "medicine"], ["びょういん", "hospital"], ["いしゃ", "doctor"], ["かんごし", "nurse"]],
-  "grammar": [["しんさつ", "しんさつ", "medical examination"], ["ちゅうしゃ", "ちゅうしゃ", "injection"], ["けっさ", "けっさ", "blood test"], ["レントゲン", "レントゲン", "X-ray"], ["しょほうせん", "しょほうせん", "prescription"]],
-  "practice": {
-    "pattern": "〜が　いたいです / 〜が　かゆいです",
-    "meaning": "~ hurts / ~ is itchy",
-    "example_jp": "せんせい、のどが　いたくて、ねつが　あります",
-    "example_en": "Doctor, my throat hurts and I have a fever"
-  },
-  "tip": "Practice a doctor's visit dialogue: describe your symptoms and ask for medicine."
-}, {
-  "day": 97,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "Health & Illness",
-  "intro": "Common illness and health vocabulary.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["かぜ", "cold (illness)"], ["ねつ", "fever"], ["せき", "cough"], ["はなみず", "runny nose"], ["ずつう", "headache"]],
-  "grammar": [["きぶんがわるい", "きぶんがわるい", "feel sick/unwell"], ["つかれた", "つかれた", "tired/exhausted"], ["ねむい", "ねむい", "sleepy"], ["げんき", "げんき", "healthy/energetic"], ["かいふく", "かいふく", "recovery"]],
-  "practice": {
-    "pattern": "〜の　ちょうしが　わるいです",
-    "meaning": "My ~ is not in good shape",
-    "example_jp": "きのうから　かぜの　ちょうしです",
-    "example_en": "I've had a cold since yesterday"
-  },
-  "tip": "Write about the last time you were sick: what happened, what symptoms did you have?"
-}, {
-  "day": 98,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "Body Review",
-  "intro": "Review all body vocabulary with a description exercise.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [],
-  "grammar": [["あたま", "あたま", "head"], ["かお", "かお", "face"], ["て", "て", "hand"], ["あし", "あし", "leg/foot"], ["からだ", "からだ", "body"]],
-  "practice": {
-    "pattern": "からだに　きをつけてください",
-    "meaning": "Please take care of your body/health",
-    "example_jp": "まいにち　うんどうして、からだに　きをつけています",
-    "example_en": "I exercise every day and take care of my health"
-  },
-  "tip": "Describe a person's appearance (head to toe) in 5-6 sentences."
-}, {
-  "day": 99,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 14,
-  "title": "Colors: Basic",
-  "intro": "あか=red, あお=blue, きいろ=yellow. Essential colors for daily life.",
-  "type": "lesson",
-  "chars": [["あか", "red"], ["あお", "blue"], ["きいろ", "yellow"], ["しろ", "white"], ["くろ", "black"]],
-  "vocab": [["みどり", "みどり", "green"], ["ちゃいろ", "ちゃいろ", "brown"], ["オレンジ", "オレンジ", "orange"], ["ピンク", "ピンク", "pink"], ["むらさき", "むらさき", "purple"]],
-  "grammar": {
-    "pattern": "〜は　なにいろですか",
-    "meaning": "What color is ~?",
-    "example_jp": "そのバッグは　なにいろですか。くろです",
-    "example_en": "What color is that bag? It's black"
-  },
-  "practice": "Ask what color 5 objects are and answer in Japanese.",
-  "tip": "あかい/あおい/きいろい/しろい/くろい are い-adjectives. But みどり、loanwords use noun+の: みどりの　くるま (green car)."
-}, {
-  "day": 100,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 15,
-  "title": "Colors in Sentences",
-  "intro": "Describing things by color in natural sentences.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["あかい　りんご", "あかい　りんご", "red apple"], ["あおい　そら", "あおい　そら", "blue sky"], ["きいろい　はな", "きいろい　はな", "yellow flower"], ["くろい　くるま", "くろい　くるま", "black car"], ["しろい　ゆき", "しろい　ゆき", "white snow"]],
-  "grammar": {
-    "pattern": "〜いろの〜",
-    "meaning": "a ~ colored ~",
-    "example_jp": "みどりいろの　ドレスが　すきです",
-    "example_en": "I like a green dress"
-  },
-  "practice": "Describe 5 things in your environment using color adjectives.",
-  "tip": "Japanese traffic lights: the 'go' light is called あお (blue) even though it looks green! Historical linguistic usage."
-}, {
-  "day": 101,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 15,
-  "title": "Shapes & Sizes",
-  "intro": "Basic shapes and size vocabulary.",
-  "type": "lesson",
-  "chars": [["まる", "circle"], ["しかく", "square"], ["さんかく", "triangle"], ["ながしかく", "rectangle"], ["ほし", "star"]],
-  "vocab": [["おおきい", "おおきい", "big"], ["ちいさい", "ちいさい", "small"], ["まるい", "まるい", "round"], ["ほそい", "ほそい", "thin"], ["ふとい", "ふとい", "thick/fat"]],
-  "grammar": {
-    "pattern": "〜い　かたちです",
-    "meaning": "It is a ~ shape",
-    "example_jp": "このつくえは　ながしかくです",
-    "example_en": "This desk is rectangular"
-  },
-  "practice": "Describe the shape and size of 5 objects around you.",
-  "tip": "まるい (round) is an い-adjective. まる (circle) is a noun. Both are useful in different contexts!"
-}, {
-  "day": 102,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 15,
-  "title": "Food: Basic",
-  "intro": "Core food vocabulary for dining and cooking.",
-  "type": "lesson",
-  "chars": [["ごはん", "rice/meal"], ["パン", "bread"], ["にく", "meat"], ["さかな", "fish"], ["やさい", "vegetables"]],
-  "vocab": [["くだもの", "くだもの", "fruit"], ["たまご", "たまご", "egg"], ["チーズ", "チーズ", "cheese"], ["とりにく", "とりにく", "chicken"], ["ぶたにく", "ぶたにく", "pork"]],
-  "grammar": {
-    "pattern": "〜が　すきです",
-    "meaning": "I like ~",
-    "example_jp": "やさいが　すきですが、にくは　あまり　すきじゃないです",
-    "example_en": "I like vegetables but don't really like meat"
-  },
-  "practice": "Write about your food preferences: 3 things you like and 2 you don't.",
-  "tip": "ごはん means both 'cooked rice' AND 'meal': あさごはん=breakfast, ひるごはん=lunch, ばんごはん=dinner."
-}, {
-  "day": 103,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 15,
-  "title": "Japanese Cuisine",
-  "intro": "Traditional Japanese dishes — essential for dining in Japan.",
-  "type": "lesson",
-  "chars": [["すし", "sushi"], ["ラーメン", "ramen"], ["てんぷら", "tempura"], ["うどん", "udon"], ["そば", "soba"]],
-  "vocab": [["おにぎり", "おにぎり", "rice ball"], ["みそしる", "みそしる", "miso soup"], ["やきとり", "やきとり", "grilled chicken"], ["たこやき", "たこやき", "octopus balls"], ["おこのみやき", "おこのみやき", "savory pancake"]],
-  "grammar": {
-    "pattern": "〜を　ください",
-    "meaning": "Please give me ~",
-    "example_jp": "ラーメンを　ひとつと　ぎょうざを　ふたつ　ください",
-    "example_en": "One ramen and two gyoza please"
-  },
-  "practice": "Memorise 5 Japanese dishes and practice ordering them.",
-  "tip": "Japan has incredible regional food specialties. ラーメン has regional styles, たこやき is from Osaka. Food is a great cultural entry point!"
-}, {
-  "day": 104,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 15,
-  "title": "Drinks",
-  "intro": "Beverage vocabulary.",
-  "type": "lesson",
-  "chars": [["みず", "water"], ["おちゃ", "green tea"], ["コーヒー", "coffee"], ["ジュース", "juice"], ["ビール", "beer"]],
-  "vocab": [["ぎゅうにゅう", "ぎゅうにゅう", "milk"], ["コーラ", "コーラ", "cola"], ["おさけ", "おさけ", "alcohol"], ["ワイン", "ワイン", "wine"], ["ウーロンちゃ", "ウーロンちゃ", "oolong tea"]],
-  "grammar": {
-    "pattern": "〜を　いっぱい　ください",
-    "meaning": "One cup/glass of ~ please",
-    "example_jp": "アイスコーヒーを　ひとつ　ください",
-    "example_en": "One iced coffee please"
-  },
-  "practice": "Practice ordering drinks at a cafe.",
-  "tip": "お茶 in Japan = green tea. For black tea say こうちゃ. Convenience stores have an amazing variety of tea!"
-}, {
-  "day": 105,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 15,
-  "title": "Food Adjectives",
-  "intro": "Describing food and handling restaurant situations.",
-  "type": "lesson",
-  "chars": [["おいしい", "delicious"], ["まずい", "bad-tasting"], ["あまい", "sweet"], ["からい", "spicy"], ["しょっぱい", "salty"]],
-  "vocab": [["すっぱい", "すっぱい", "sour"], ["にがい", "にがい", "bitter"], ["あっさり", "あっさり", "light flavour"], ["こってり", "こってり", "rich/heavy"], ["おすすめ", "おすすめ", "recommendation"]],
-  "grammar": {
-    "pattern": "〜は　どんな　あじですか",
-    "meaning": "What does ~ taste like?",
-    "example_jp": "このカレーは　からくて　おいしいです",
-    "example_en": "This curry is spicy and delicious"
-  },
-  "practice": "Describe your favourite meal using food adjectives.",
-  "tip": "おいしい！ is the #1 compliment in Japan. Say it enthusiastically — it will make any Japanese cook happy!"
-}, {
-  "day": 106,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 16,
-  "title": "Places: Town",
-  "intro": "Places you visit in daily life.",
-  "type": "lesson",
-  "chars": [["えき", "station"], ["スーパー", "supermarket"], ["コンビニ", "convenience store"], ["びょういん", "hospital"], ["ゆうびんきょく", "post office"]],
-  "vocab": [["ぎんこう", "ぎんこう", "bank"], ["としょかん", "としょかん", "library"], ["デパート", "デパート", "department store"], ["くうこう", "くうこう", "airport"], ["バスてい", "バスてい", "bus stop"]],
-  "grammar": {
-    "pattern": "〜に　いきます",
-    "meaning": "I go to ~",
-    "example_jp": "まいあさ　コンビニに　よって　コーヒーを　かいます",
-    "example_en": "Every morning I stop by the convenience store and buy coffee"
-  },
-  "practice": "Write where you go each day of the week.",
-  "tip": "コンビニ is a Japanese institution! Open 24/7, they sell food, pay bills, print documents, and much more."
-}, {
-  "day": 107,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 16,
-  "title": "Places: School & Work",
-  "intro": "Educational and workplace vocabulary.",
-  "type": "lesson",
-  "chars": [["がっこう", "school"], ["だいがく", "university"], ["かいしゃ", "company"], ["じむしょ", "office"], ["きょうしつ", "classroom"]],
-  "vocab": [["としょしつ", "としょしつ", "school library"], ["たいいくかん", "たいいくかん", "gymnasium"], ["しょくどう", "しょくどう", "cafeteria"], ["かいぎしつ", "かいぎしつ", "meeting room"], ["うけつけ", "うけつけ", "reception"]],
-  "grammar": {
-    "pattern": "〜で　はたらいています",
-    "meaning": "I work at ~",
-    "example_jp": "わたしは　ちいさな　かいしゃで　はたらいています",
-    "example_en": "I work at a small company"
-  },
-  "practice": "Describe your school or workplace.",
-  "tip": "日本語学校 (にほんごがっこう) = Japanese language school. Many foreigners study at these in Japan!"
-}, {
-  "day": 108,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 16,
-  "title": "Nature & Outdoors",
-  "intro": "Outdoor locations.",
-  "type": "lesson",
-  "chars": [["こうえん", "park"], ["やま", "mountain"], ["かわ", "river"], ["うみ", "sea"], ["もり", "forest"]],
-  "vocab": [["のはら", "のはら", "field"], ["たき", "たき", "waterfall"], ["しま", "しま", "island"], ["みずうみ", "みずうみ", "lake"], ["そら", "そら", "sky"]],
-  "grammar": {
-    "pattern": "〜に　いってみたいです",
-    "meaning": "I'd like to try going to ~",
-    "example_jp": "いつか　ふじさんに　のぼってみたいです",
-    "example_en": "Someday I'd like to try climbing Mt. Fuji"
-  },
-  "practice": "Write about a natural place you'd like to visit in Japan.",
-  "tip": "Japan's must-see nature: ふじさん, 日光 (にっこう), 白川郷 (しらかわごう). Which would you visit first?"
-}, {
-  "day": 109,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 16,
-  "title": "Directions",
-  "intro": "How to give and understand directions.",
-  "type": "lesson",
-  "chars": [["まっすぐ", "straight ahead"], ["みぎ", "right"], ["ひだり", "left"], ["まがる", "turn"], ["とまる", "stop"]],
-  "vocab": [["しんごう", "しんごう", "traffic light"], ["かど", "かど", "corner"], ["〜をすぎて", "〜をすぎて", "past ~"], ["ちかくです", "ちかくです", "it's nearby"], ["とおいです", "とおいです", "it's far"]],
-  "grammar": {
-    "pattern": "〜をみぎに　まがってください",
-    "meaning": "Please turn right at ~",
-    "example_jp": "つぎのしんごうを　ひだりに　まがって、まっすぐいくと　えきがあります",
-    "example_en": "Turn left at the next light, go straight, and you'll find the station"
-  },
-  "practice": "Practice giving directions from your home to the nearest station.",
-  "tip": "Useful phrase: すみません、〜はどこですか. In Japan, showing a map on your phone is also very effective!"
-}, {
-  "day": 110,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 16,
-  "title": "Weather",
-  "intro": "Weather expressions for daily small talk.",
-  "type": "lesson",
-  "chars": [["はれ", "sunny"], ["くもり", "cloudy"], ["あめ", "rain"], ["ゆき", "snow"], ["かぜ", "wind"]],
-  "vocab": [["きり", "きり", "fog"], ["かみなり", "かみなり", "thunder"], ["たいふう", "たいふう", "typhoon"], ["てんきよほう", "てんきよほう", "weather forecast"], ["きおん", "きおん", "temperature"]],
-  "grammar": {
-    "pattern": "きょうの　てんきは〜です",
-    "meaning": "Today's weather is ~",
-    "example_jp": "あしたは　あめの　ちです。かさを　もっていって！",
-    "example_en": "It will probably rain tomorrow. Take an umbrella!"
-  },
-  "practice": "Describe today's weather and your weekly forecast.",
-  "tip": "Japan has 4 distinct seasons AND a rainy season (つゆ/梅雨, June-July). Weather small talk is extremely common!"
-}, {
-  "day": 111,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 16,
-  "title": "Seasons",
-  "intro": "The four seasons and seasonal vocabulary.",
-  "type": "lesson",
-  "chars": [["はる", "spring"], ["なつ", "summer"], ["あき", "autumn"], ["ふゆ", "winter"], ["きせつ", "season"]],
-  "vocab": [["あたたかい", "あたたかい", "warm"], ["あつい", "あつい", "hot"], ["すずしい", "すずしい", "cool"], ["さむい", "さむい", "cold"], ["さくら", "さくら", "cherry blossom"]],
-  "grammar": {
-    "pattern": "〜は　〜が　いちばん　すきです",
-    "meaning": "I like ~ the most in ~",
-    "example_jp": "わたしは　あきが　いちばん　すきです。すずしくて　きれいです",
-    "example_en": "I like autumn the most. It's cool and beautiful"
-  },
-  "practice": "Which season do you like best and why? Write 3-4 sentences.",
-  "tip": "Cherry blossom (さくら) season and autumn foliage (こうよう) are Japan's most celebrated seasonal events!"
-}, {
-  "day": 112,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 17,
-  "title": "Animals: Common",
-  "intro": "Common animals.",
-  "type": "lesson",
-  "chars": [["いぬ", "dog"], ["ねこ", "cat"], ["とり", "bird"], ["さかな", "fish"], ["うま", "horse"]],
-  "vocab": [["うし", "うし", "cow"], ["ぶた", "ぶた", "pig"], ["うさぎ", "うさぎ", "rabbit"], ["くま", "くま", "bear"], ["さる", "さる", "monkey"]],
-  "grammar": {
-    "pattern": "〜を　かっています",
-    "meaning": "I keep ~ as a pet",
-    "example_jp": "いえで　ねこを　にひき　かっています",
-    "example_en": "I keep two cats at home"
-  },
-  "practice": "Do you have pets? Describe them using body and personality adjectives.",
-  "tip": "Japanese animal sounds: dog=ワンワン, cat=ニャーニャー, frog=ゲロゲロ. Very different from English!"
-}, {
-  "day": 113,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 17,
-  "title": "Animals: Wild & More",
-  "intro": "Wild and exotic animals.",
-  "type": "lesson",
-  "chars": [["ぞう", "elephant"], ["らいおん", "lion"], ["きりん", "giraffe"], ["とら", "tiger"], ["しろくま", "polar bear"]],
-  "vocab": [["たぬき", "たぬき", "raccoon dog"], ["きつね", "きつね", "fox"], ["しか", "しか", "deer"], ["へび", "へび", "snake"], ["さかな", "さかな", "fish"]],
-  "grammar": {
-    "pattern": "〜は　〜より　おおきいです",
-    "meaning": "~ is bigger than ~",
-    "example_jp": "ぞうは　きりんより　おもいです",
-    "example_en": "Elephants are heavier than giraffes"
-  },
-  "practice": "Compare 3 pairs of animals using より.",
-  "tip": "たぬき (tanuki/raccoon dog) appears everywhere in Japanese folklore — look for ceramic statues outside shops for good luck!"
-}, {
-  "day": 114,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 17,
-  "title": "Nature & Sky",
-  "intro": "Natural world vocabulary.",
-  "type": "lesson",
-  "chars": [["そら", "sky"], ["つき", "moon"], ["ほし", "star"], ["たいよう", "sun"], ["くも", "cloud"]],
-  "vocab": [["はな", "はな", "flower"], ["き", "き", "tree"], ["くさ", "くさ", "grass"], ["いし", "いし", "stone"], ["つち", "つち", "earth/soil"]],
-  "grammar": {
-    "pattern": "〜がきれいですね",
-    "meaning": "~ is beautiful, isn't it",
-    "example_jp": "こんばん　ほしが　きれいですね",
-    "example_en": "The stars are beautiful tonight, aren't they"
-  },
-  "practice": "Describe your favourite natural scenery in Japanese.",
-  "tip": "Japanese has poetic nature words like 木漏れ日 (こもれび) = sunlight filtering through leaves. Nature has deep cultural significance in Japan!"
-}, {
-  "day": 115,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 17,
-  "title": "Hobbies & Free Time",
-  "intro": "Common hobby vocabulary.",
-  "type": "lesson",
-  "chars": [["しゅみ", "hobby"], ["スポーツ", "sports"], ["おんがく", "music"], ["えいが", "movie"], ["りょこう", "travel"]],
-  "vocab": [["どくしょ", "どくしょ", "reading"], ["りょうり", "りょうり", "cooking"], ["ゲーム", "ゲーム", "gaming"], ["えをかく", "えをかく", "drawing"], ["うたう", "うたう", "singing"]],
-  "grammar": {
-    "pattern": "しゅみは　〜です",
-    "meaning": "My hobby is ~",
-    "example_jp": "しゅみは　りょこうと　にほんごの　べんきょうです",
-    "example_en": "My hobbies are travel and studying Japanese"
-  },
-  "practice": "Introduce your hobbies. Ask someone else about their hobbies.",
-  "tip": "〜がすきです (I like ~) focuses on preference; 〜をしています (I do ~) focuses on activity. Both natural for hobbies!"
-}, {
-  "day": 116,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 17,
-  "title": "Daily Routine",
-  "intro": "Verbs and times for a typical day.",
-  "type": "lesson",
-  "chars": [["おきる", "wake up"], ["シャワーをあびる", "shower"], ["あさごはん", "breakfast"], ["がっこうにいく", "go to school"], ["かえる", "return home"]],
-  "vocab": [["ばんごはん", "ばんごはん", "dinner"], ["ふろにはいる", "ふろにはいる", "take a bath"], ["テレビをみる", "テレビをみる", "watch TV"], ["ねる", "ねる", "sleep"], ["はをみがく", "はをみがく", "brush teeth"]],
-  "grammar": {
-    "pattern": "まいにち　〜ます",
-    "meaning": "I ~ every day",
-    "example_jp": "まいあさ　ろくじに　おきて、シャワーをあびて、あさごはんを　たべます",
-    "example_en": "Every morning I wake up at 6, shower, and eat breakfast"
-  },
-  "practice": "Write your complete daily routine from morning to night.",
-  "tip": "Japanese routines often chain actions with the て-form: おきて、シャワーをあびて、ごはんをたべて... (Phase 5 covers this!)"
-}, {
-  "day": 117,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 18,
-  "title": "School Vocabulary",
-  "intro": "School-related vocabulary.",
-  "type": "lesson",
-  "chars": [["じゅぎょう", "class"], ["せんせい", "teacher"], ["がくせい", "student"], ["しゅくだい", "homework"], ["テスト", "test"]],
-  "vocab": [["やすみじかん", "やすみじかん", "break time"], ["たいいく", "たいいく", "P.E."], ["りか", "りか", "science"], ["すうがく", "すうがく", "math"], ["えいご", "えいご", "English"]],
-  "grammar": {
-    "pattern": "〜を　べんきょうしています",
-    "meaning": "I am studying ~",
-    "example_jp": "いま　にほんごを　べんきょうしています",
-    "example_en": "I am currently studying Japanese"
-  },
-  "practice": "Write about your favourite school subject and why.",
-  "tip": "Japanese school subjects: こくご (Japanese lit.), えいご (English), すうがく (math), りか (science), しゃかい (social studies), おんがく (music), びじゅつ (art)."
-}, {
-  "day": 118,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 18,
-  "title": "Work & Career",
-  "intro": "Work-related vocabulary.",
-  "type": "lesson",
-  "chars": [["しごと", "work"], ["かいしゃ", "company"], ["かいぎ", "meeting"], ["しゃいん", "employee"], ["きゅうりょう", "salary"]],
-  "vocab": [["きゅうか", "きゅうか", "paid leave"], ["ざんぎょう", "ざんぎょう", "overtime"], ["しゅっちょう", "しゅっちょう", "business trip"], ["めいし", "めいし", "business card"], ["ぶちょう", "ぶちょう", "department head"]],
-  "grammar": {
-    "pattern": "〜で　はたらいています",
-    "meaning": "I work at ~",
-    "example_jp": "IT かいしゃで　エンジニアとして　はたらいています",
-    "example_en": "I work as an engineer at an IT company"
-  },
-  "practice": "Describe your current or ideal job in Japanese.",
-  "tip": "Business cards (めいし) are exchanged with both hands and a bow in Japan — treat them with great respect!"
-}, {
-  "day": 119,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 18,
-  "title": "Shopping",
-  "intro": "Shopping vocabulary and phrases.",
-  "type": "lesson",
-  "chars": [["みせ", "shop"], ["ねだん", "price"], ["わりびき", "discount"], ["うりきれ", "sold out"], ["レジ", "cash register"]],
-  "vocab": [["いくらですか", "いくらですか", "How much?"], ["〜をみせてください", "〜をみせてください", "Please show me ~"], ["おつり", "おつり", "change (money)"], ["ふくろ", "ふくろ", "bag"], ["クレジットカード", "クレジットカード", "credit card"]],
-  "grammar": {
-    "pattern": "〜を　〜つ　ください",
-    "meaning": "Please give me ~ of ~",
-    "example_jp": "このTシャツのMサイズをください",
-    "example_en": "Please give me a medium-size of this T-shirt"
-  },
-  "practice": "Practice a shopping dialogue: ask the price, buy an item, receive change.",
-  "tip": "In Japan: ふくろはいりますか (Do you need a bag?) — plastic bags cost extra. Say だいじょうぶです to decline politely!"
-}, {
-  "day": 120,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 18,
-  "title": "い-Adjective Review",
-  "intro": "Comprehensive review of all い-adjectives learned.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["おおきい/ちいさい", "おおきい/ちいさい", "big/small"], ["たかい/やすい", "たかい/やすい", "expensive/cheap"], ["あたらしい/ふるい", "あたらしい/ふるい", "new/old"], ["おいしい/まずい", "おいしい/まずい", "delicious/bad"], ["たのしい/つまらない", "たのしい/つまらない", "fun/boring"]],
-  "grammar": {
-    "pattern": "〜くて、〜いです",
-    "meaning": "~ and ~ (chaining)",
-    "example_jp": "このレストランは　やすくて　おいしくて　にぎやかです",
-    "example_en": "This restaurant is cheap, delicious, and lively"
-  },
-  "practice": "Write 5 sentences using 2 chained い-adjectives.",
-  "tip": "KEY: い-adjectives conjugate. Present: 〜い、Neg: 〜くない、Past: 〜かった、Past neg: 〜くなかった. いい→よかった (irregular!)"
-}, {
-  "day": 121,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 18,
-  "title": "な-Adjective Review",
-  "intro": "Comprehensive review of な-adjectives.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["しずかな/にぎやかな", "しずかな/にぎやかな", "quiet/lively"], ["きれいな/きたない", "きれいな/きたない", "beautiful/dirty"], ["べんりな/ふべんな", "べんりな/ふべんな", "convenient/inconvenient"], ["げんきな/びょうきな", "げんきな/びょうきな", "healthy/sick"], ["すきな/きらいな", "すきな/きらいな", "liked/disliked"]],
-  "grammar": {
-    "pattern": "〜で、〜です (na-adj chain)",
-    "meaning": "~ and ~",
-    "example_jp": "このまちは　しずかで　きれいで　べんりです",
-    "example_en": "This town is quiet, beautiful, and convenient"
-  },
-  "practice": "Describe your ideal town/home using な-adjectives.",
-  "tip": "な-adjective chaining uses で (not て). Mixed chains: やすくて　きれいです (cheap and beautiful — い then な)."
-}, {
-  "day": 122,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 19,
-  "title": "Likes & Dislikes",
-  "intro": "Expressing preferences and abilities.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["〜がすきです", "〜がすきです", "I like ~"], ["〜がきらいです", "〜がきらいです", "I dislike ~"], ["〜がとくいです", "〜がとくいです", "I'm good at ~"], ["〜がにがてです", "〜がにがてです", "I'm bad at ~"], ["〜がほしいです", "〜がほしいです", "I want ~ (thing)"]],
-  "grammar": {
-    "pattern": "〜がいちばんすきです",
-    "meaning": "I like ~ the most",
-    "example_jp": "たべものの　なかで　ラーメンが　いちばん　すきです",
-    "example_en": "Among foods, I like ramen the most"
-  },
-  "practice": "Write your top 3 likes and dislikes in food, hobbies, and subjects.",
-  "tip": "Note: すき and きらい take が, not を! 'I like sushi' = すしが すきです (NOT すしを すきです)."
-}, {
-  "day": 123,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 19,
-  "title": "Core Verbs Review",
-  "intro": "Review of all verbs introduced so far.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["たべる・のむ", "たべる・のむ", "eat/drink"], ["いく・くる・かえる", "いく・くる・かえる", "go/come/return"], ["みる・きく・よむ", "みる・きく・よむ", "see/listen/read"], ["かく・はなす・かう", "かく・はなす・かう", "write/speak/buy"], ["おきる・ねる・やすむ", "おきる・ねる・やすむ", "wake/sleep/rest"]],
-  "grammar": {
-    "pattern": "〜て、〜て、〜ます (chaining)",
-    "meaning": "Do ~, do ~, and do ~",
-    "example_jp": "まいあさ　おきて、べんきょうして、しごとに　いきます",
-    "example_en": "Every morning I wake up, study, and go to work"
-  },
-  "practice": "Write your daily routine using 5 different verbs.",
-  "tip": "Keep a verb notebook! Organize by type: RU-verbs (drop る, add ます) and U-verbs (stem changes). We'll master these in Phase 5!"
-}, {
-  "day": 124,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 19,
-  "title": "Adverbs of Degree",
-  "intro": "Adverbs that modify adjectives: とても、すこし、あまり.",
-  "type": "lesson",
-  "chars": [["とても", "very"], ["すこし", "a little"], ["かなり", "quite"], ["すごく", "very (casual)"], ["ちょっと", "a little (casual)"]],
-  "vocab": [["あまり〜ない", "あまり〜ない", "not very ~"], ["ぜんぜん〜ない", "ぜんぜん〜ない", "not at all ~"], ["もっと", "もっと", "more"], ["たくさん", "たくさん", "a lot"], ["ほとんど〜ない", "ほとんど〜ない", "hardly ~"]],
-  "grammar": {
-    "pattern": "とても/すごく　〜です",
-    "meaning": "very ~",
-    "example_jp": "きょうは　すごく　あついですね！",
-    "example_en": "It's very hot today, isn't it!"
-  },
-  "practice": "Add degree adverbs to 5 sentences to make them sound more natural.",
-  "tip": "あまり and ぜんぜん ALWAYS go with negative verbs (ません). Never: あまりたべます. Correct: あまりたべません."
-}, {
-  "day": 125,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 19,
-  "title": "Question Words Review",
-  "intro": "All question words (疑問詞) in one place.",
-  "type": "lesson",
-  "chars": [["なに/なん", "what"], ["だれ", "who"], ["いつ", "when"], ["どこ", "where"], ["なぜ/どうして", "why"]],
-  "vocab": [["どう", "どう", "how (manner)"], ["どんな", "どんな", "what kind of"], ["どのくらい", "どのくらい", "how much/long"], ["いくつ", "いくつ", "how many"], ["いくら", "いくら", "how much (price)"]],
-  "grammar": {
-    "pattern": "〜は　どこですか / いつですか / なんですか",
-    "meaning": "Where/When/What is ~?",
-    "example_jp": "つぎの　でんしゃは　なんじですか",
-    "example_en": "What time is the next train?"
-  },
-  "practice": "Create 5 different questions using different question words.",
-  "tip": "Question words go where the answer would go: だれがきますか (Who is coming?) — だれ replaces the person's name. Logical!"
-}, {
-  "day": 126,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 19,
-  "title": "Vocabulary Midpoint Review",
-  "intro": "Review days 85-125 — all vocabulary learned in Phase 4 so far.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["かぞく", "かぞく", "family"], ["からだ", "からだ", "body"], ["たべもの", "たべもの", "food"], ["ばしょ", "ばしょ", "place"], ["てんき", "てんき", "weather"]],
-  "grammar": {
-    "pattern": "〜について　はなしてください",
-    "meaning": "Please talk about ~",
-    "example_jp": "あなたの　かぞくに　ついて　はなしてください",
-    "example_en": "Please tell me about your family"
-  },
-  "practice": "Answer in Japanese: What did you eat today? Where do you live? What are your hobbies? Who is your best friend?",
-  "tip": "Half of Phase 4 complete! The key to retention: use words in sentences, not just memorise lists. Make a vocab journal!"
-}, {
-  "day": 127,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 19,
-  "title": "い-Adj: Emotions & Feelings",
-  "intro": "Emotion and feeling adjectives.",
-  "type": "lesson",
-  "chars": [["うれしい", "happy/glad"], ["かなしい", "sad"], ["こわい", "scary"], ["たのしい", "fun"], ["つらい", "painful/tough"]],
-  "vocab": [["はずかしい", "はずかしい", "embarrassed"], ["さびしい", "さびしい", "lonely"], ["ねむい", "ねむい", "sleepy"], ["いたい", "いたい", "painful"], ["びっくりした", "びっくりした", "surprised"]],
-  "grammar": {
-    "pattern": "〜くて　たまりません",
-    "meaning": "I can't stand how ~",
-    "example_jp": "さびしくて　たまりません",
-    "example_en": "I can't stand the loneliness"
-  },
-  "practice": "Express your current feelings in Japanese. Write 3 emotion sentences.",
-  "tip": "Japanese often expresses emotions indirectly. Sometimes 〜です alone isn't enough — adding ね or よ adds emotional nuance!"
-}, {
-  "day": 128,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 20,
-  "title": "Personality Adjectives",
-  "intro": "Describing personality traits.",
-  "type": "lesson",
-  "chars": [["やさしい", "kind/gentle"], ["おもしろい", "interesting/funny"], ["まじめ(な)", "serious/diligent"], ["あかるい", "bright/cheerful"], ["おとなしい", "quiet/gentle"]],
-  "vocab": [["しんせつ(な)", "しんせつ(な)", "kind/helpful"], ["ゆうき(な)", "ゆうき(な)", "courageous"], ["のんき(な)", "のんき(な)", "easygoing"], ["なまけもの", "なまけもの", "lazy person"], ["がんばりや", "がんばりや", "hardworking person"]],
-  "grammar": {
-    "pattern": "〜は　〜な　ひとです",
-    "meaning": "~ is a ~ person",
-    "example_jp": "かれは　やさしくて　まじめな　ひとです",
-    "example_en": "He is a kind and serious person"
-  },
-  "practice": "Describe your personality and the personality of someone you admire.",
-  "tip": "Personality adjectives mix い and な types: やさしい (い-adj), まじめ (な-adj). Watch out for the different usage rules!"
-}, {
-  "day": 129,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 20,
-  "title": "Size & Quantity",
-  "intro": "Expressing size, amount and quantity.",
-  "type": "lesson",
-  "chars": [["おおい", "many/a lot (quantity)"], ["すくない", "few/little"], ["おおきい", "big (size)"], ["ちいさい", "small (size)"], ["ひろい", "wide/spacious"]],
-  "vocab": [["せまい", "せまい", "narrow/cramped"], ["ふかい", "ふかい", "deep"], ["あさい", "あさい", "shallow"], ["おもい", "おもい", "heavy"], ["かるい", "かるい", "light (weight)"]],
-  "grammar": {
-    "pattern": "〜が　おおいです/すくないです",
-    "meaning": "There are many/few ~",
-    "example_jp": "このまちは　ひとが　おおくて　にぎやかです",
-    "example_en": "This town has many people and is lively"
-  },
-  "practice": "Describe your room or city using quantity and size adjectives.",
-  "tip": "Note: おおい (many) and すくない (few) are い-adjectives about QUANTITY. おおきい (big) is about SIZE. Don't confuse them!"
-}, {
-  "day": 130,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 20,
-  "title": "Speed & Distance",
-  "intro": "Speed, distance, and movement vocabulary.",
-  "type": "lesson",
-  "chars": [["はやい", "fast/early"], ["おそい", "slow/late"], ["とおい", "far"], ["ちかい", "near/close"], ["まっすぐ", "straight"]],
-  "vocab": [["すぐに", "すぐに", "immediately/soon"], ["ゆっくり", "ゆっくり", "slowly"], ["だいたい", "だいたい", "approximately"], ["〜キロ", "〜キロ", "~ kilometres"], ["〜ふん(かかる)", "〜ふん(かかる)", "takes ~ minutes"]],
-  "grammar": {
-    "pattern": "〜から　〜まで　〜ぷんかかります",
-    "meaning": "It takes ~ minutes from ~ to ~",
-    "example_jp": "えきから　うちまで　あるいて　じゅっぷんかかります",
-    "example_en": "It takes 10 minutes to walk from the station to my house"
-  },
-  "practice": "Describe distances: how far is the station, supermarket, school from your home?",
-  "tip": "かかります (it takes) is used for time and money. じかんがかかります (it takes time), おかねがかかります (it costs money)."
-}, {
-  "day": 131,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 20,
-  "title": "Transport",
-  "intro": "Transportation vocabulary.",
-  "type": "lesson",
-  "chars": [["でんしゃ", "train"], ["バス", "bus"], ["じてんしゃ", "bicycle"], ["くるま", "car"], ["ひこうき", "airplane"]],
-  "vocab": [["タクシー", "タクシー", "taxi"], ["ちかてつ", "ちかてつ", "subway"], ["しんかんせん", "しんかんせん", "bullet train"], ["ふね", "ふね", "ship/boat"], ["あるく", "あるく", "walk"]],
-  "grammar": {
-    "pattern": "〜で　いきます",
-    "meaning": "I go by ~",
-    "example_jp": "まいにち　ちかてつで　かいしゃに　いきます",
-    "example_en": "I go to work by subway every day"
-  },
-  "practice": "Describe how you get to different places: school, supermarket, airport.",
-  "tip": "Japan's public transport is world-famous for punctuality! The しんかんせん (bullet train) is a must-try experience."
-}, {
-  "day": 132,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 20,
-  "title": "Time Expressions",
-  "intro": "Advanced time expressions for nuanced conversations.",
-  "type": "lesson",
-  "chars": [["いつも", "always"], ["よく", "often"], ["ときどき", "sometimes"], ["めったに〜ない", "rarely"], ["ぜんぜん〜ない", "never"]],
-  "vocab": [["もうすぐ", "もうすぐ", "soon/almost time"], ["まだ", "まだ", "still/not yet"], ["もう", "もう", "already/anymore"], ["さっき", "さっき", "just now/a moment ago"], ["あとで", "あとで", "later"]],
-  "grammar": {
-    "pattern": "まだ〜ていません",
-    "meaning": "haven't ~ yet",
-    "example_jp": "まだ　あさごはんを　たべていません",
-    "example_en": "I haven't eaten breakfast yet"
-  },
-  "practice": "Write sentences using each time expression.",
-  "tip": "まだ+negative = not yet. もう+negative = not anymore. もう+positive = already. Three meanings with two words — context is key!"
-}, {
-  "day": 133,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 20,
-  "title": "Technology & Modern Life",
-  "intro": "Modern technology vocabulary essential for daily life.",
-  "type": "lesson",
-  "chars": [["スマートフォン", "smartphone"], ["コンピューター", "computer"], ["インターネット", "internet"], ["メール", "email"], ["アプリ", "app"]],
-  "vocab": [["SNS", "SNS", "social media"], ["ダウンロード", "ダウンロード", "download"], ["パスワード", "パスワード", "password"], ["じゅうでん", "じゅうでん", "charging (battery)"], ["でんぱ", "でんぱ", "signal/radio waves"]],
-  "grammar": {
-    "pattern": "〜を　つかっています",
-    "meaning": "I use ~",
-    "example_jp": "まいにち　スマートフォンで　メールを　よみます",
-    "example_en": "I read email on my smartphone every day"
-  },
-  "practice": "Write how you use technology in your daily life.",
-  "tip": "Japan is tech-savvy! IC cards (like Suica) for transport, cashless payments, and LINE (messaging app) are part of daily life."
-}, {
-  "day": 134,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 20,
-  "title": "Clothing",
-  "intro": "Clothing vocabulary.",
-  "type": "lesson",
-  "chars": [["シャツ", "shirt"], ["ズボン", "pants/trousers"], ["スカート", "skirt"], ["くつ", "shoes"], ["ぼうし", "hat"]],
-  "vocab": [["うわぎ", "うわぎ", "jacket/top"], ["コート", "コート", "coat"], ["ふく", "ふく", "clothes"], ["おしゃれ(な)", "おしゃれ(な)", "fashionable"], ["サイズ", "サイズ", "size"]],
-  "grammar": {
-    "pattern": "〜を　きています",
-    "meaning": "wearing ~ (upper body)",
-    "example_jp": "きょう　あかい　シャツを　きています",
-    "example_en": "Today I'm wearing a red shirt"
-  },
-  "practice": "Describe what you're wearing today and what you usually wear.",
-  "tip": "着る (きる) = wear (upper body clothes). はく = wear (lower body: pants, shoes). かぶる = wear (head: hats). Different verbs for different body parts!"
-}, {
-  "day": 135,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 21,
-  "title": "Money & Numbers Review",
-  "intro": "Money expressions and large number practice.",
-  "type": "lesson",
-  "chars": [["おかね", "money"], ["さいふ", "wallet"], ["りょうがえ", "currency exchange"], ["ぜいきん", "tax"], ["むりょう", "free (no charge)"]],
-  "vocab": [["〜えん", "〜えん", "~ yen"], ["〜ドル", "〜ドル", "~ dollars"], ["たかい", "たかい", "expensive"], ["やすい", "やすい", "cheap"], ["ただ", "ただ", "free (slang)"]],
-  "grammar": {
-    "pattern": "〜えんです",
-    "meaning": "It is ~ yen",
-    "example_jp": "このくつは　いちまんえんです。たかい！",
-    "example_en": "These shoes are 10,000 yen. Expensive!"
-  },
-  "practice": "Practice: how would you say prices in a Japanese shop? ¥1,500, ¥8,000, ¥23,400.",
-  "tip": "Japan is largely a cash society, though カード (card) payment is now common. Always carry some cash!"
-}, {
-  "day": 136,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 21,
-  "title": "Food Culture",
-  "intro": "Japanese food culture and dining customs.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["いただきます", "いただきます", "let's eat (before meals)"], ["ごちそうさまでした", "ごちそうさまでした", "thank you for the meal"], ["わりかん", "わりかん", "splitting the bill"], ["おごる", "おごる", "treat someone"], ["〜をたのむ", "〜をたのむ", "to order ~"]],
-  "grammar": {
-    "pattern": "〜を　たのみましょうか",
-    "meaning": "Shall we order ~?",
-    "example_jp": "なにを　たのみますか。わたしはラーメンに　します",
-    "example_en": "What will you order? I'll have ramen"
-  },
-  "practice": "Practice a restaurant dialogue from start to finish: entering, ordering, paying.",
-  "tip": "Japanese dining etiquette: don't stick chopsticks upright in rice (funeral symbolism), don't pass food chopstick to chopstick (also funeral custom). Learn the taboos!"
-}, {
-  "day": 137,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 21,
-  "title": "Health & Body Care",
-  "intro": "Health maintenance and body care vocabulary.",
-  "type": "lesson",
-  "chars": [["うんどう", "exercise"], ["たいそう", "calisthenics/gymnastics"], ["ダイエット", "diet"], ["すいみん", "sleep"], ["えいよう", "nutrition"]],
-  "vocab": [["けんこう(な)", "けんこう(な)", "healthy"], ["からだにいい", "からだにいい", "good for health"], ["からだにわるい", "からだにわるい", "bad for health"], ["ストレス", "ストレス", "stress"], ["きゅうけい", "きゅうけい", "rest/break"]],
-  "grammar": {
-    "pattern": "〜は　からだに　いいです",
-    "meaning": "~ is good for your body/health",
-    "example_jp": "まいにち　うんどうすることは　からだに　いいです",
-    "example_en": "Exercising every day is good for your body"
-  },
-  "practice": "Write 5 health tips in Japanese.",
-  "tip": "Japanese people rank among the world's longest-lived. Habits: walking, balanced diet (washoku/和食), regular work and social connection."
-}, {
-  "day": 138,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 21,
-  "title": "At the Post Office & Bank",
-  "intro": "Post office and bank vocabulary — practical for life in Japan.",
-  "type": "lesson",
-  "chars": [["ゆうびんきょく", "post office"], ["きって", "stamp"], ["てがみ", "letter"], ["こづつみ", "package"], ["ぎんこう", "bank"]],
-  "vocab": [["こうざ", "こうざ", "bank account"], ["おろす", "おろす", "withdraw money"], ["ふりこむ", "ふりこむ", "transfer money"], ["ATM", "ATM", "ATM"], ["てすうりょう", "てすうりょう", "service fee"]],
-  "grammar": {
-    "pattern": "〜を　おくりたいのですが",
-    "meaning": "I'd like to send ~",
-    "example_jp": "この　こづつみを　アメリカに　おくりたいのですが",
-    "example_en": "I'd like to send this package to America"
-  },
-  "practice": "Practice: how do you ask to send a package? open a bank account? withdraw money?",
-  "tip": "Japanese post offices (郵便局) also function as banks! Very convenient for opening an account as a foreigner."
-}, {
-  "day": 139,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 21,
-  "title": "Review: Verbs & Vocabulary",
-  "intro": "Comprehensive review of all Phase 4 vocabulary with JLPT-style exercises.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["にほんごで　いってください", "にほんごで　いってください", "please say it in Japanese"], ["もういちど", "もういちど", "once more / again"], ["わすれました", "わすれました", "I forgot"], ["もうすこし", "もうすこし", "a little more"], ["じゅうぶんです", "じゅうぶんです", "that's enough / sufficient"]],
-  "grammar": {
-    "pattern": "JLPT vocabulary exercise",
-    "meaning": "Practice matching",
-    "example_jp": "つぎのことばの　いみを　えらんでください",
-    "example_en": "Please choose the meaning of the following word"
-  },
-  "practice": "Take a self-quiz: cover the English column and test yourself on all Phase 4 vocabulary.",
-  "tip": "JLPT N5 requires ~800 vocabulary words. You're building that foundation now. Flash cards (Anki) are a powerful tool for retention!"
-}, {
-  "day": 140,
-  "phaseNum": 4,
-  "phaseName": "Vocabulary",
-  "week": 21,
-  "title": "Vocabulary Phase Complete!",
-  "intro": "Congratulations — you've completed Phase 4! Review and celebrate your progress.",
-  "type": "lesson",
-  "chars": [],
-  "vocab": [["おめでとうございます", "おめでとうございます", "congratulations!"], ["よくできました", "よくできました", "well done!"], ["もっとがんばります", "もっとがんばります", "I'll work even harder"], ["じしん", "じしん", "confidence"], ["にほんご", "にほんご", "Japanese language"]],
-  "grammar": {
-    "pattern": "〜を　がんばっています",
-    "meaning": "I'm working hard at ~",
-    "example_jp": "まいにち　にほんごを　がんばって　べんきょうしています",
-    "example_en": "I work hard at studying Japanese every day"
-  },
-  "practice": "Write a reflection: What vocabulary surprised you? What do you want to practice more?",
-  "tip": "You've completed 140 days! You now have a strong vocabulary base. Phase 5 tackles verb conjugation — the key to expressing actions and experiences in Japanese!"
-}, {
-  "day": 141,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 21,
-  "title": "Verb Groups: RU-verbs",
-  "intro": "Japanese verbs fall into groups. RU-verbs (Group 2): drop る, add ます. Easy!",
-  "type": "verbs",
-  "chars": [["たべる→たべます", "eat"], ["みる→みます", "see/watch"], ["おきる→おきます", "wake up"], ["ねる→ねます", "sleep"], ["でる→でます", "exit/leave"]],
-  "vocab": [["おしえる", "おしえます", "teach"], ["おぼえる", "おぼえます", "memorise"], ["かりる", "かります", "borrow"], ["しめる", "しめます", "close"], ["あける", "あけます", "open"]],
-  "grammar": {
-    "pattern": "RU-verb: stem + ます",
-    "meaning": "Polite present/future",
-    "example_jp": "まいにち　にほんごを　べんきょうします",
-    "example_en": "I study Japanese every day"
-  },
-  "practice": "List 10 RU-verbs and conjugate them: ます、ません、ました、ませんでした.",
-  "tip": "Rule: RU-verbs end in る after an e or i sound: たべ+る, み+る, お+き+る. But careful — some う-verbs also end in る (e.g. はしる = run)!"
-}, {
-  "day": 142,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 21,
-  "title": "More RU-verbs",
-  "intro": "Expanding RU-verb vocabulary.",
-  "type": "verbs",
-  "chars": [["きる→きます", "wear (clothing)"], ["おりる→おります", "get off (transport)"], ["かける→かけます", "hang/dial"], ["つける→つけます", "turn on"], ["かえる→かえます", "change"]],
-  "vocab": [["すてる", "すてます", "throw away"], ["やめる", "やめます", "quit/stop"], ["はじめる", "はじめます", "start/begin"], ["おえる", "おえます", "finish"], ["あつめる", "あつめます", "collect"]],
-  "grammar": {
-    "pattern": "〜を　はじめます/おえます",
-    "meaning": "start/finish ~",
-    "example_jp": "しごとを　くじに　はじめて、ごじに　おえます",
-    "example_en": "I start work at 9 and finish at 5"
-  },
-  "practice": "Conjugate all 10 verbs above in all 4 polite forms.",
-  "tip": "はじめる (start) vs はじまる (starts by itself). This transitive/intransitive pair is important! Many Japanese verbs come in such pairs."
-}, {
-  "day": 143,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 22,
-  "title": "U-verbs: Introduction",
-  "intro": "U-verbs (Group 1) conjugate by changing the final sound of the stem.",
-  "type": "verbs",
-  "chars": [["かく→かきます", "write"], ["よむ→よみます", "read"], ["のむ→のみます", "drink"], ["はなす→はなします", "speak"], ["かう→かいます", "buy"]],
-  "vocab": [["きく", "ききます", "listen/ask"], ["まつ", "まちます", "wait"], ["あそぶ", "あそびます", "play"], ["おもう", "おもいます", "think"], ["うごく", "うごきます", "move"]],
-  "grammar": {
-    "pattern": "U-verb conjugation: く→き, ぐ→ぎ, す→し, つ→ち, ぬ→に, ぶ→び, む→み, る→り, う→い",
-    "meaning": "Stem change for polite form",
-    "example_jp": "まいにち　にっきを　かきます",
-    "example_en": "I write in a diary every day"
-  },
-  "practice": "Conjugate: かく、よむ、はなす、まつ、かう in all 4 polite forms.",
-  "tip": "U-verb rule: find the dictionary form, identify the last syllable, change it following the い-row pattern, then add ます."
-}, {
-  "day": 144,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 22,
-  "title": "Irregular Verbs: する & くる",
-  "intro": "Only 2 truly irregular verbs in Japanese: する (do) and くる (come).",
-  "type": "verbs",
-  "chars": [["する→します", "do"], ["くる→きます", "come"], ["べんきょうする→します", "study"], ["りょうこうする→します", "travel"], ["でんわする→します", "phone"]],
-  "vocab": [["かいものする", "かいものします", "go shopping"], ["うんどうする", "うんどうします", "exercise"], ["りょうりする", "りょうりします", "cook"], ["そうじする", "そうじします", "clean"], ["せんたくする", "せんたくします", "do laundry"]],
-  "grammar": {
-    "pattern": "(noun)する",
-    "meaning": "do (noun)",
-    "example_jp": "まいにち　べんきょうして、うんどうして、りょうりします",
-    "example_en": "Every day I study, exercise, and cook"
-  },
-  "practice": "List 5 する-compound verbs related to your daily life.",
-  "tip": "する compounds are extremely productive! Almost any noun can become a verb by adding する: ゲームする (play games), ドライブする (go for a drive), チェックする (check)."
-}, {
-  "day": 145,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 22,
-  "title": "て-form: RU-verbs",
-  "intro": "The て-form is one of the most versatile forms. RU-verb て-form: drop る, add て. Easy!",
-  "type": "verbs",
-  "chars": [["たべる→たべて", "eat"], ["みる→みて", "see"], ["おきる→おきて", "wake up"], ["ねる→ねて", "sleep"], ["でる→でて", "exit"]],
-  "vocab": [["おしえて", "おしえて", "teach (te-form)"], ["おぼえて", "おぼえて", "memorise (te-form)"], ["あけて", "あけて", "open (te-form)"], ["しめて", "しめて", "close (te-form)"], ["すてて", "すてて", "throw away (te-form)"]],
-  "grammar": {
-    "pattern": "〜て　ください",
-    "meaning": "Please ~",
-    "example_jp": "ここに　すわって　ください",
-    "example_en": "Please sit here"
-  },
-  "practice": "Convert 10 RU-verbs to て-form. Then make てください requests.",
-  "tip": "て-form has MANY uses: requests (てください), sequential actions (〜て〜て), progressive (ている), permission (てもいい), prohibition (てはいけない). Master it!"
-}, {
-  "day": 146,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 22,
-  "title": "て-form: U-verbs",
-  "intro": "U-verb て-form: stem changes! く→いて, ぐ→いで, す→して, つ→って, ぬ→んで, ぶ→んで, む→んで, う→って.",
-  "type": "verbs",
-  "chars": [["かく→かいて", "write→writing"], ["よむ→よんで", "read→reading"], ["のむ→のんで", "drink→drinking"], ["はなす→はなして", "speak→speaking"], ["まつ→まって", "wait→waiting"]],
-  "vocab": [["かう→かって", "かって", "buy (te-form)"], ["きく→きいて", "きいて", "listen (te-form)"], ["いく→いって", "いって", "go (te-form) *special"], ["あそぶ→あそんで", "あそんで", "play (te-form)"], ["かえる→かえって", "かえって", "return (te-form)"]],
-  "grammar": {
-    "pattern": "〜て、〜て、〜ます",
-    "meaning": "Do ~, do ~, do ~",
-    "example_jp": "おきて、シャワーをあびて、ごはんをたべます",
-    "example_en": "(I) wake up, shower, and eat"
-  },
-  "practice": "Convert 10 U-verbs to て-form. Write a morning routine chaining 5 actions with て.",
-  "tip": "Special case: いく (go) → いって (NOT いいて). Just this one exception to remember! All other く verbs follow the rule: く→いて."
-}, {
-  "day": 147,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 22,
-  "title": "て-form: Irregular & Practice",
-  "intro": "て-form of する (して) and くる (きて), plus full practice.",
-  "type": "verbs",
-  "chars": [["する→して", "do→doing"], ["くる→きて", "come→coming"], ["べんきょうする→べんきょうして", "study→studying"], ["りょうりする→りょうりして", "cook→cooking"], ["うんどうする→うんどうして", "exercise→exercising"]],
-  "vocab": [["して", "して", "do (te-form)"], ["きて", "きて", "come (te-form)"], ["おねがいして", "おねがいして", "please (requesting)"], ["れんしゅうして", "れんしゅうして", "practice (te-form)"], ["かくにんして", "かくにんして", "confirm (te-form)"]],
-  "grammar": {
-    "pattern": "て-form review",
-    "meaning": "All verb types",
-    "example_jp": "まいにち　はやく　おきて、べんきょうして、うんどうして、りょうりします",
-    "example_en": "Every day I wake up early, study, exercise, and cook"
-  },
-  "practice": "Write a full daily schedule chaining 7+ actions with て-form.",
-  "tip": "て-form mastery is the key to sounding natural in Japanese. Spend extra time today — it's worth it!"
-}, {
-  "day": 148,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 22,
-  "title": "〜ている: Progressive",
-  "intro": "たべている = (I am) eating. ている expresses an ongoing action or resulting state.",
-  "type": "verbs",
-  "chars": [["たべている", "eating"], ["はなしている", "speaking"], ["みている", "watching"], ["はしっている", "running"], ["まっている", "waiting"]],
-  "vocab": [["いま　なにをしていますか", "いま　なにをしていますか", "What are you doing now?"], ["ねています", "ねています", "(is) sleeping"], ["べんきょうしています", "べんきょうしています", "(is) studying"], ["てをあらっています", "てをあらっています", "washing hands"], ["あるいています", "あるいています", "walking"]],
-  "grammar": {
-    "pattern": "〜ています",
-    "meaning": "is doing ~ (progressive)",
-    "example_jp": "いま　でんしゃに　のっています",
-    "example_en": "I am currently on the train"
-  },
-  "practice": "Describe what 5 people around you are doing right now.",
-  "tip": "〜ています has TWO uses: ongoing action (たべています = is eating) AND resulting state (けっこんしています = is married). Context tells you which!"
-}, {
-  "day": 149,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 23,
-  "title": "〜ている: Resulting State",
-  "intro": "ている can also describe the state that results from a completed action.",
-  "type": "verbs",
-  "chars": [["けっこんしている", "be married (state from marrying)"], ["しっている", "know (state from learning)"], ["すんでいる", "live (state from moving)"], ["つとめている", "work at (state from being employed)"], ["ならっている", "be learning (state of study)"]],
-  "vocab": [["しっています", "しっています", "I know (I have learned)"], ["しりません", "しりません", "I don't know"], ["すんでいます", "すんでいます", "I live (in ~)"], ["けっこんしています", "けっこんしています", "I am married"], ["もっています", "もっています", "I have / I am holding"]],
-  "grammar": {
-    "pattern": "〜に　すんでいます",
-    "meaning": "I live in ~",
-    "example_jp": "いまは　とうきょうに　すんでいます",
-    "example_en": "I currently live in Tokyo"
-  },
-  "practice": "Write 3 sentences using ている for ongoing actions and 3 for resulting states.",
-  "tip": "Important: しっています (I know) vs しりません (I don't know). NOT しっていません! しる is a U-verb used in ている form for 'knowledge state'."
-}, {
-  "day": 150,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 23,
-  "title": "Past Tense Review",
-  "intro": "Comprehensive review of ました, ませんでした, and plain past forms.",
-  "type": "verbs",
-  "chars": [],
-  "vocab": [["〜ました", "〜ました", "did ~ (polite past)"], ["〜ませんでした", "〜ませんでした", "didn't ~ (polite past)"], ["〜た", "〜た", "did ~ (plain past)"], ["〜なかった", "〜なかった", "didn't ~ (plain past)"], ["きのう", "きのう", "yesterday"]],
-  "grammar": {
-    "pattern": "きのう　〜ました",
-    "meaning": "Yesterday I ~",
-    "example_jp": "きのう　ともだちと　えいがを　みました",
-    "example_en": "Yesterday I watched a movie with a friend"
-  },
-  "practice": "Write about what you did yesterday using 5 different verbs in past tense.",
-  "tip": "Plain past (た-form) is used in casual speech and inside clauses. Polite past (ました) is for polite sentences. Both essential!"
-}, {
-  "day": 151,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 23,
-  "title": "Negative て-form: 〜ないで",
-  "intro": "〜ないでください = Please don't ~. Also used to mean 'without doing ~'.",
-  "type": "verbs",
-  "chars": [["たべないでください", "please don't eat"], ["みないでください", "please don't watch"], ["わすれないでください", "please don't forget"], ["はなさないでください", "please don't speak"], ["しんぱいしないでください", "please don't worry"]],
-  "vocab": [["〜ないで", "〜ないで", "without doing ~"], ["ねないで　べんきょうした", "ねないで　べんきょうした", "studied without sleeping"], ["ごはんをたべないで　きた", "ごはんをたべないで　きた", "came without eating"], ["しんぱいしないで！", "しんぱいしないで！", "Don't worry!"], ["あきらめないで！", "あきらめないで！", "Don't give up!"]],
-  "grammar": {
-    "pattern": "〜ないでください",
-    "meaning": "Please don't ~",
-    "example_jp": "ここで　タバコを　すわないでください",
-    "example_en": "Please don't smoke here"
-  },
-  "practice": "Write 5 polite prohibitions using ないでください. Then 3 'without doing' sentences.",
-  "tip": "〜ないでください is softer than 〜てはいけません (must not). Use ないでください for polite requests; てはいけません for rules and prohibitions."
-}, {
-  "day": 152,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 23,
-  "title": "〜たい: Want to Do",
-  "intro": "〜たいです = I want to ~. たい is an い-adjective attached to the verb stem.",
-  "type": "verbs",
-  "chars": [["たべたい", "want to eat"], ["みたい", "want to see"], ["いきたい", "want to go"], ["かいたい", "want to buy"], ["はなしたい", "want to speak"]],
-  "vocab": [["にほんに　いきたいです", "にほんに　いきたいです", "I want to go to Japan"], ["にほんごを　はなしたい", "にほんごを　はなしたい", "I want to speak Japanese"], ["〜たくないです", "〜たくないです", "don't want to ~"], ["〜たかったです", "〜たかったです", "wanted to ~"], ["〜たくなかったです", "〜たくなかったです", "didn't want to ~"]],
-  "grammar": {
-    "pattern": "〜たいです",
-    "meaning": "I want to ~",
-    "example_jp": "いつか　にほんに　いって、ラーメンを　たべたいです",
-    "example_en": "Someday I want to go to Japan and eat ramen"
-  },
-  "practice": "List 5 things you want to do in Japan.",
-  "tip": "たい conjugates like an い-adjective: たくない (don't want to), たかった (wanted to). Very systematic! But たい only expresses YOUR OWN desires, not guessing others."
-}, {
-  "day": 153,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 23,
-  "title": "〜てもいい: Permission",
-  "intro": "〜てもいいですか = May I ~? 〜てもいいです = You may ~.",
-  "type": "verbs",
-  "chars": [["たべてもいいですか", "may I eat?"], ["みてもいいですか", "may I see/watch?"], ["はなしてもいいですか", "may I speak?"], ["つかってもいいですか", "may I use?"], ["きいてもいいですか", "may I ask?"]],
-  "vocab": [["〜てもいいですよ", "〜てもいいですよ", "you may ~ (giving permission)"], ["〜てはいけません", "〜てはいけません", "you must not ~ (prohibition)"], ["〜てもかまいません", "〜てもかまいません", "I don't mind if you ~"], ["どうぞ", "どうぞ", "please go ahead"], ["ちょっと...", "ちょっと...", "that's a bit... (indirect refusal)"]],
-  "grammar": {
-    "pattern": "〜てもいいですか",
-    "meaning": "May I ~?",
-    "example_jp": "しゃしんを　とってもいいですか",
-    "example_en": "May I take a photo?"
-  },
-  "practice": "Practice asking permission in 5 situations: at a restaurant, museum, friend's house, office, shop.",
-  "tip": "In Japan, explicitly asking permission is very important and appreciated. Don't assume — always ask with 〜てもいいですか!"
-}, {
-  "day": 154,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 24,
-  "title": "〜なければなりません: Must",
-  "intro": "〜なければなりません = must do ~. Shortened casual form: 〜なきゃ.",
-  "type": "verbs",
-  "chars": [["たべなければなりません", "must eat"], ["べんきょうしなければなりません", "must study"], ["いかなければなりません", "must go"], ["はやくおきなければなりません", "must wake up early"], ["かならず〜しなければなりません", "must definitely ~"]],
-  "vocab": [["〜なければなりません", "〜なければなりません", "must ~"], ["〜なきゃ", "〜なきゃ", "must ~ (casual)"], ["〜なくてもいいです", "〜なくてもいいです", "don't have to ~"], ["しなければいけません", "しなければいけません", "must do (alt. form)"], ["ぎむ", "ぎむ", "obligation"]],
-  "grammar": {
-    "pattern": "〜なければなりません",
-    "meaning": "must ~",
-    "example_jp": "くすりを　のまなければなりません",
-    "example_en": "I must take medicine"
-  },
-  "practice": "Write 5 obligations using なければなりません (study, work, sleep, exercise, eat).",
-  "tip": "Long but important! Shortcut: Verb ない-form → drop い → add きゃ: たべなきゃ (casual 'gotta eat'). Very common in speech!"
-}, {
-  "day": 155,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 24,
-  "title": "〜なくてもいい: Don't Have To",
-  "intro": "〜なくてもいいです = don't have to ~. Used with permissions and freedoms.",
-  "type": "verbs",
-  "chars": [["たべなくてもいいです", "don't have to eat"], ["いかなくてもいいです", "don't have to go"], ["しなくてもいいです", "don't have to do"], ["はらわなくてもいいです", "don't have to pay"], ["しんぱいしなくてもいいです", "don't have to worry"]],
-  "vocab": [["〜なくてもいいですよ", "〜なくてもいいですよ", "you don't have to ~"], ["やすんでもいいですよ", "やすんでもいいですよ", "you may rest"], ["むりしなくてもいいです", "むりしなくてもいいです", "you don't have to push yourself"], ["きがるに", "きがるに", "feel free to"], ["おかまいなく", "おかまいなく", "please don't worry about me"]],
-  "grammar": {
-    "pattern": "〜なくてもいいです",
-    "meaning": "don't have to ~",
-    "example_jp": "きょうは　かいしゃに　いかなくてもいいです",
-    "example_en": "You don't have to go to the office today"
-  },
-  "practice": "Write 5 situations where you DON'T have to do something (weekend, holiday, etc.).",
-  "tip": "The 4 permission/obligation forms in a nutshell: ていい (may), てはいけない (must not), なければならない (must), なくてもいい (don't have to). Master these 4!"
-}, {
-  "day": 156,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 24,
-  "title": "〜ことができる: Can / Ability",
-  "intro": "〜ことができます = can do ~. Also: できます alone = can, is possible.",
-  "type": "verbs",
-  "chars": [["にほんごをはなすことができます", "can speak Japanese"], ["ピアノをひくことができます", "can play piano"], ["〜ができます", "can do ~"], ["〜ができません", "cannot do ~"], ["〜ができましたか", "could you ~? / were you able to ~?"]],
-  "vocab": [["できます", "できます", "can / is possible"], ["できません", "できません", "cannot"], ["〜がとくいです", "〜がとくいです", "good at ~"], ["〜がにがてです", "〜がにがてです", "not good at ~"], ["れんしゅうすればできます", "れんしゅうすればできます", "with practice you can do it"]],
-  "grammar": {
-    "pattern": "〜ことができます",
-    "meaning": "can ~",
-    "example_jp": "にほんごで　かんたんな　かいわが　できます",
-    "example_en": "I can have a simple conversation in Japanese"
-  },
-  "practice": "List 5 things you can do and 3 things you can't do yet (but want to learn).",
-  "tip": "できます can be used alone: にほんごができます (I can [do] Japanese). ことができます is more formal. Both are common and correct!"
-}, {
-  "day": 157,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 24,
-  "title": "〜てから: After Doing",
-  "intro": "〜てから = after doing ~. Describes a sequence where the first action must complete first.",
-  "type": "verbs",
-  "chars": [["たべてから　はをみがきます", "brush teeth after eating"], ["しゅくだいをしてから　あそびます", "play after doing homework"], ["シャワーをあびてから　ねます", "sleep after showering"], ["にほんに　いってから　わかりました", "understood after going to Japan"], ["かんがえてから　こたえます", "answer after thinking"]],
-  "vocab": [["〜てから", "〜てから", "after doing ~"], ["〜たあとで", "〜たあとで", "after ~ (past completed action)"], ["〜まえに", "〜まえに", "before ~"], ["じゅんばん", "じゅんばん", "order/sequence"], ["まず", "まず", "first of all"]],
-  "grammar": {
-    "pattern": "〜てから　〜ます",
-    "meaning": "After doing ~, do ~",
-    "example_jp": "てを　あらってから　たべましょう",
-    "example_en": "Let's eat after washing our hands"
-  },
-  "practice": "Write 5 sentences showing a sequence of activities in your day.",
-  "tip": "〜てから vs 〜たあとで: てから = immediately after (the order matters). たあとで = sometime after (looser connection). Both are very natural!"
-}, {
-  "day": 158,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 24,
-  "title": "〜まえに: Before Doing",
-  "intro": "〜まえに = before doing ~. The verb before まえに stays in DICTIONARY form.",
-  "type": "verbs",
-  "chars": [["たべるまえに　てをあらいます", "wash hands before eating"], ["ねるまえに　はをみがきます", "brush teeth before sleeping"], ["でかけるまえに　かぎをかけます", "lock up before going out"], ["しけんのまえに　べんきょうします", "study before the exam"], ["しぬまえに　にほんにいきたい", "want to go to Japan before dying"]],
-  "vocab": [["〜まえに", "〜まえに", "before ~"], ["じゅんび", "じゅんび", "preparation"], ["よやく", "よやく", "reservation/booking"], ["かくにん", "かくにん", "confirmation"], ["ちゅうい", "ちゅうい", "caution/warning"]],
-  "grammar": {
-    "pattern": "〜るまえに",
-    "meaning": "before doing ~",
-    "example_jp": "にほんに　いくまえに　にほんごを　べんきょうします",
-    "example_en": "I study Japanese before going to Japan"
-  },
-  "practice": "Write 5 things you do before important events (exam, trip, meeting).",
-  "tip": "KEY: まえに uses DICTIONARY form (たべるまえに), while あとで uses PAST form (たべたあとで). Many students mix these up!"
-}, {
-  "day": 159,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 25,
-  "title": "〜ながら: While Doing",
-  "intro": "〜ながら = while doing ~. Used when two actions happen simultaneously (same subject).",
-  "type": "verbs",
-  "chars": [["おんがくをききながらべんきょうします", "study while listening to music"], ["あるきながらたべます", "eat while walking"], ["テレビをみながらしょくじします", "eat while watching TV"], ["はなしながらあるきます", "walk while talking"], ["わらいながらいいました", "said (it) while laughing"]],
-  "vocab": [["〜ながら", "〜ながら", "while doing ~"], ["どうじに", "どうじに", "at the same time"], ["〜つつ", "〜つつ", "while ~ (formal)"], ["いっぽうで", "いっぽうで", "on the other hand"], ["マルチタスク", "マルチタスク", "multitasking"]],
-  "grammar": {
-    "pattern": "〜ながら　〜ます",
-    "meaning": "do ~ while doing ~",
-    "example_jp": "コーヒーを　のみながら　にほんごを　べんきょうします",
-    "example_en": "I study Japanese while drinking coffee"
-  },
-  "practice": "What do you do simultaneously? List 5 ながら activities.",
-  "tip": "ながら: main action comes AFTER ながら. The action before ながら is the background activity: おんがくを（きき）ながら（べんきょうします）. The study is the focus!"
-}, {
-  "day": 160,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 25,
-  "title": "〜と思います: I Think That",
-  "intro": "〜とおもいます = I think that ~. The clause before と uses plain form.",
-  "type": "verbs",
-  "chars": [["たかいとおもいます", "I think it's expensive"], ["いいとおもいます", "I think it's good"], ["にほんごはむずかしいとおもいます", "I think Japanese is difficult"], ["かれはきっとくるとおもいます", "I think he will surely come"], ["わかりませんが、そうだとおもいます", "I'm not sure but I think so"]],
-  "vocab": [["〜とおもいます", "〜とおもいます", "I think that ~"], ["〜とおもっています", "〜とおもっています", "I have been thinking that ~"], ["〜かもしれません", "〜かもしれません", "might be / perhaps"], ["〜でしょう", "〜でしょう", "probably / I think"], ["〜はずです", "〜はずです", "should be / expected to be"]],
-  "grammar": {
-    "pattern": "〜とおもいます",
-    "meaning": "I think that ~",
-    "example_jp": "にほんごは　むずかしいですが、たのしいとおもいます",
-    "example_en": "I think Japanese is difficult, but fun"
-  },
-  "practice": "Express 5 opinions using とおもいます.",
-  "tip": "〜とおもいます is essential for polite opinion-giving. Japanese culture values indirect expression — とおもいます softens opinions perfectly!"
-}, {
-  "day": 161,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 25,
-  "title": "〜てあげる・もらう・くれる: Giving & Receiving",
-  "intro": "Three verbs for giving and receiving actions (not objects).",
-  "type": "verbs",
-  "chars": [["〜てあげます", "do for (outward — I/we → them)"], ["〜てもらいます", "receive the doing of (I/we ← them)"], ["〜てくれます", "give to me/us (they → me/us)"], ["おしえてあげます", "teach (for them)"], ["てつだってもらいます", "receive help"]],
-  "vocab": [["たすけてくれました", "たすけてくれました", "(they) helped me"], ["かしてあげました", "かしてあげました", "lent (to them)"], ["みせてもらいました", "みせてもらいました", "was shown (by them)"], ["〜てくれてありがとう", "〜てくれてありがとう", "thank you for doing ~"], ["〜てあげましょうか", "〜てあげましょうか", "Shall I do ~ for you?"]],
-  "grammar": {
-    "pattern": "〜てくれてありがとう",
-    "meaning": "Thank you for ~ing (for me)",
-    "example_jp": "たすけてくれて　ありがとうございます",
-    "example_en": "Thank you for helping me"
-  },
-  "practice": "Write 5 sentences about things done for you, things you did for others.",
-  "tip": "The direction matters! あげる = you give/do for others. もらう = you receive from others. くれる = they give/do FOR YOU. Draw arrows to remember!"
-}, {
-  "day": 162,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 25,
-  "title": "〜に行く: Going to Do",
-  "intro": "〜にいきます = go (somewhere) in order to ~. Express purpose of travel.",
-  "type": "verbs",
-  "chars": [["たべにいきます", "go to eat"], ["かいものにいきます", "go shopping"], ["あそびにいきます", "go to play/hang out"], ["みにいきます", "go to see"], ["べんきょうしにいきます", "go to study"]],
-  "vocab": [["〜にいく", "〜にいく", "go to do ~"], ["〜にくる", "〜にくる", "come to do ~"], ["〜にかえる", "〜にかえる", "return to do ~"], ["もくてき", "もくてき", "purpose"], ["〜ために", "〜ために", "for the purpose of ~"]],
-  "grammar": {
-    "pattern": "〜に　いきます",
-    "meaning": "go to do ~",
-    "example_jp": "レストランに　ランチを　たべに　いきます",
-    "example_en": "I'm going to the restaurant to eat lunch"
-  },
-  "practice": "Write 5 sentences about where you go and why (purpose).",
-  "tip": "The structure: place + に + verb stem + に + いきます. 'I go to [place] to [do verb]': スーパーにかいものにいきます = I go to the supermarket to shop."
-}, {
-  "day": 163,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 25,
-  "title": "Verb Review: All Forms",
-  "intro": "Comprehensive review of all verb forms learned in Phase 5 so far.",
-  "type": "verbs",
-  "chars": [],
-  "vocab": [["〜ます/ません", "〜ます/ません", "present polite"], ["〜ました/ませんでした", "〜ました/ませんでした", "past polite"], ["〜て", "〜て", "te-form"], ["〜ている", "〜ている", "progressive/state"], ["〜たい", "〜たい", "want to"]],
-  "grammar": {
-    "pattern": "Verb conjugation summary",
-    "meaning": "All polite forms",
-    "example_jp": "たべます、たべません、たべました、たべませんでした、たべて、たべている、たべたい",
-    "example_en": "eat, don't eat, ate, didn't eat, eating (te), is eating, want to eat"
-  },
-  "practice": "Make a conjugation table for 5 verbs (one of each type: RU, U, する, くる).",
-  "tip": "Create a verb conjugation cheat sheet! This is the most valuable study tool you can make at this stage."
-}, {
-  "day": 164,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 26,
-  "title": "Plain Form: Present/Future",
-  "intro": "The plain (dictionary) form is used in casual speech and inside clauses.",
-  "type": "verbs",
-  "chars": [["たべる", "eat (plain)"], ["のむ", "drink (plain)"], ["いく", "go (plain)"], ["する", "do (plain)"], ["くる", "come (plain)"]],
-  "vocab": [["〜とおもう", "〜とおもう", "think that ~ (casual)"], ["〜かもしれない", "〜かもしれない", "might be (casual)"], ["〜んだ", "〜んだ", "explanation (casual)"], ["〜よね", "〜よね", "right? (seeking agreement)"], ["〜でしょ", "〜でしょ", "right? (asserting)"]],
-  "grammar": {
-    "pattern": "〜と　おもう (casual)",
-    "meaning": "I think ~ (casual)",
-    "example_jp": "あしたは　あめが　ふると　おもう",
-    "example_en": "I think it'll rain tomorrow"
-  },
-  "practice": "Practice writing in casual (plain) form — as if texting a friend.",
-  "tip": "Casual Japanese drops ます/です and uses plain forms. Essential for understanding anime, manga, and conversations among friends!"
-}, {
-  "day": 165,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 26,
-  "title": "Plain Negative: ない-form",
-  "intro": "Plain negative form: ない-form. RU-verbs: drop る, add ない. U-verbs: change to あ-row + ない.",
-  "type": "verbs",
-  "chars": [["たべない", "don't eat (plain)"], ["みない", "don't see (plain)"], ["いかない", "don't go (plain)"], ["しない", "don't do (plain)"], ["こない", "don't come (plain)"]],
-  "vocab": [["〜ないとおもう", "〜ないとおもう", "think won't ~"], ["〜ないかもしれない", "〜ないかもしれない", "might not ~"], ["〜なければ", "〜なければ", "if not ~ / must ~"], ["〜ないで", "〜ないで", "without doing"], ["〜ずに", "〜ずに", "without doing (formal)"]],
-  "grammar": {
-    "pattern": "〜ないとおもいます",
-    "meaning": "I don't think ~ will ~",
-    "example_jp": "かれは　こないとおもいます",
-    "example_en": "I don't think he'll come"
-  },
-  "practice": "Conjugate 10 verbs to plain negative form.",
-  "tip": "U-verb ない rule: change the final う-sound to あ-row: く→かない, ぐ→がない, す→さない, つ→たない, ぬ→なない, ぶ→ばない, む→まない, う→わない (NOT あない!)"
-}, {
-  "day": 166,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 26,
-  "title": "Plain Past: た-form",
-  "intro": "た-form (plain past) is formed the same way as て-form but with た/だ instead of て/で.",
-  "type": "verbs",
-  "chars": [["たべた", "ate (plain)"], ["みた", "saw (plain)"], ["いった", "went (plain)"], ["した", "did (plain)"], ["きた", "came (plain)"]],
-  "vocab": [["〜たとおもいます", "〜たとおもいます", "I think ~ happened"], ["〜たことがあります", "〜たことがあります", "have experienced ~"], ["〜たあとで", "〜たあとで", "after ~"], ["〜たら", "〜たら", "if/when ~ (conditional)"], ["〜たり〜たりします", "〜たり〜たりします", "do things like ~ and ~"]],
-  "grammar": {
-    "pattern": "〜たことがあります",
-    "meaning": "I have experienced ~",
-    "example_jp": "にほんに　いったことが　あります",
-    "example_en": "I have been to Japan (before)"
-  },
-  "practice": "Write 5 experiences you have had using 〜たことがあります.",
-  "tip": "〜たことがあります expresses LIFE EXPERIENCE: 'I have (at some point in my life) done ~'. This is different from just 'I did ~' (past tense). Very useful for conversation!"
-}, {
-  "day": 167,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 26,
-  "title": "〜たり〜たりする: Listing Actions",
-  "intro": "〜たり〜たりします = do things like ~ and ~. Used to give examples of activities (not exhaustive list).",
-  "type": "verbs",
-  "chars": [["たべたり　のんだりします", "eat and drink (and things like that)"], ["よんだり　かいたりします", "read and write (etc.)"], ["いったり　きたりします", "go and come (back and forth)"], ["うたったり　おどったりします", "sing and dance (etc.)"], ["やすんだり　あそんだりします", "rest and play (etc.)"]],
-  "vocab": [["〜たり〜たりします", "〜たり〜たりします", "do ~ and ~ (etc.)"], ["〜たりして", "〜たりして", "doing things like ~"], ["なにかと", "なにかと", "this and that"], ["いろいろ", "いろいろ", "various things"], ["たとえば", "たとえば", "for example"]],
-  "grammar": {
-    "pattern": "〜たり、〜たりします",
-    "meaning": "do things like ~ and ~",
-    "example_jp": "しゅうまつは　えいがをみたり、ともだちとあそんだりします",
-    "example_en": "On weekends I do things like watch movies and hang out with friends"
-  },
-  "practice": "Describe your typical weekend using たり〜たりします.",
-  "tip": "〜たり〜たりします implies the list is NOT complete — 'among other things'. Use it when giving examples, not exhaustive lists. Very natural in conversation!"
-}, {
-  "day": 168,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 27,
-  "title": "〜ば: Conditional (If)",
-  "intro": "〜ば = if ~. Used for hypothetical conditions. Verb: change final sound to え-row + ば.",
-  "type": "verbs",
-  "chars": [["たべれば", "if (you) eat"], ["いけば", "if (you) go"], ["すれば", "if (you) do"], ["くれば", "if (you) come"], ["あれば", "if there is"]],
-  "vocab": [["〜ばよかった", "〜ばよかった", "I should have ~ / wish I had ~"], ["〜ばいい", "〜ばいい", "should ~ / it's fine if ~"], ["〜ければ", "〜ければ", "if (i-adj)"], ["〜なら", "〜なら", "if ~ is the case"], ["〜たら", "〜たら", "if/when ~ (completed)"]],
-  "grammar": {
-    "pattern": "〜ばよかった",
-    "meaning": "I should have ~ / I wish I had ~",
-    "example_jp": "もっとはやく　べんきょうすれば　よかった",
-    "example_en": "I should have studied earlier"
-  },
-  "practice": "Write 3 regrets using 〜ばよかった and 3 advice sentences using 〜ばいい.",
-  "tip": "〜ばよかった is a very common expression of regret: もっと〜ばよかった (I should have done more ~). You'll use it often!"
-}, {
-  "day": 169,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 27,
-  "title": "〜たら: Conditional (When/If)",
-  "intro": "〜たら = if/when ~. Used for both hypothetical and real future conditions. た-form + ら.",
-  "type": "verbs",
-  "chars": [["たべたら", "if/when (you) eat/ate"], ["いったら", "if/when (you) go/went"], ["したら", "if/when (you) do/did"], ["きたら", "if/when (you) come/came"], ["あったら", "if/when there is/was"]],
-  "vocab": [["〜たら　どうですか", "〜たら　どうですか", "how about doing ~?"], ["〜たら　おしえてください", "〜たら　おしえてください", "let me know when ~"], ["もし〜たら", "もし〜たら", "if (hypothetical)"], ["〜たら、〜た", "〜たら、〜た", "when I did ~, ~ happened"], ["〜たらいいですか", "〜たらいいですか", "what should I do?"]],
-  "grammar": {
-    "pattern": "〜たら　どうですか",
-    "meaning": "How about ~ing?",
-    "example_jp": "いしゃに　いったら　どうですか",
-    "example_en": "How about going to a doctor?"
-  },
-  "practice": "Write 5 sentences using たら for advice, conditions, and sequences.",
-  "tip": "〜たらどうですか is a great advice-giving phrase: 'Why don't you ~?' Very useful and polite!"
-}, {
-  "day": 170,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 27,
-  "title": "〜と: Natural Consequence",
-  "intro": "〜と = when/if ~ [natural/inevitable result]. Used for habitual truths and logical outcomes.",
-  "type": "verbs",
-  "chars": [["みぎにまがると、えきがあります", "if you turn right, there's a station"], ["はるになると、さくらがさきます", "when spring comes, cherry blossoms bloom"], ["これをおすと、でます", "when you press this, it comes out"], ["おさけをのみすぎると、からだによくない", "drinking too much alcohol is bad for you"], ["まいにちれんしゅうすると、うまくなります", "if you practice every day, you'll get better"]],
-  "vocab": [["〜と", "〜と", "when/if ~ (natural consequence)"], ["かならず", "かならず", "certainly/definitely"], ["しぜんに", "しぜんに", "naturally"], ["〜のは〜だから", "〜のは〜だから", "the reason ~ is because ~"], ["〜というのは", "〜というのは", "what is called ~"]],
-  "grammar": {
-    "pattern": "〜と、〜ます",
-    "meaning": "When/if ~, ~ (natural result)",
-    "example_jp": "にほんに　いくと、おいしいものが　たくさん　あります",
-    "example_en": "When you go to Japan, there are many delicious things"
-  },
-  "practice": "Write 5 natural consequences using と.",
-  "tip": "〜と is for INEVITABLE or NATURAL results. Don't use it for choices or requests. Compare: えきにつくと、でんわします (When I arrive at the station, I'll call — natural) vs えきにつきたら、でんわしてください (When you arrive at the station, please call — request)."
-}, {
-  "day": 171,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 27,
-  "title": "Verb Phase Review 1",
-  "intro": "Review of て-form uses, ている, permission/obligation forms.",
-  "type": "verbs",
-  "chars": [],
-  "vocab": [["てください", "てください", "please do"], ["てはいけない", "てはいけない", "must not"], ["てもいい", "てもいい", "may / it's OK to"], ["なければならない", "なければならない", "must do"], ["なくてもいい", "なくてもいい", "don't have to"]],
-  "grammar": {
-    "pattern": "Quick quiz: how do you say...",
-    "meaning": "Permission/obligation review",
-    "example_jp": "しずかにしてください。ここでたべてはいけません。〜してもいいですか。",
-    "example_en": "Please be quiet. You must not eat here. May I ~?"
-  },
-  "practice": "Make a table of the 5 permission/obligation forms with one example each.",
-  "tip": "These 5 forms are essential for JLPT N5. Make flashcards: てください/てはいけない/てもいい/なければならない/なくてもいい"
-}, {
-  "day": 172,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 28,
-  "title": "Verb Phase Review 2",
-  "intro": "Review of conditional forms and giving/receiving.",
-  "type": "verbs",
-  "chars": [],
-  "vocab": [["てから", "てから", "after doing"], ["まえに", "まえに", "before doing"], ["たら", "たら", "if/when (conditional)"], ["ば", "ば", "if (hypothetical)"], ["と", "と", "when/if (natural result)"]],
-  "grammar": {
-    "pattern": "Conditional comparison",
-    "meaning": "When to use each conditional",
-    "example_jp": "ごはんをたべてから、はをみがきます。／ねるまえに、はをみがきます",
-    "example_en": "I brush my teeth after eating. / I brush my teeth before sleeping"
-  },
-  "practice": "Write a mini-story using at least 3 different conditional/sequential forms.",
-  "tip": "All 4 conditionals (たら、ば、と、なら) have different nuances. Don't stress — with practice, the right one becomes intuitive!"
-}, {
-  "day": 173,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 28,
-  "title": "〜んです/のです: Explanation",
-  "intro": "〜んです = explanatory form. Provides context or explains a situation. Very common in speech.",
-  "type": "verbs",
-  "chars": [["どうしたんですか", "what happened? / what's wrong?"], ["あたまがいたいんです", "the thing is, I have a headache"], ["ちょっとわからないんですが", "I don't quite understand, you see"], ["じつは〜んです", "actually, it's that ~"], ["〜んですね", "〜んですね", "I see, so it's that ~ (confirmation)"]],
-  "vocab": [["〜んです", "〜んです", "explanation/context (です after の/ん)"], ["じつは", "じつは", "actually / in fact"], ["〜んですが", "〜んですが", "the thing is ~ (leading to request)"], ["〜んですよね", "〜んですよね", "I see, that's right isn't it"], ["そうなんです", "そうなんです", "That's right / yes that's the thing"]],
-  "grammar": {
-    "pattern": "〜んです",
-    "meaning": "explanatory form (the thing is ~)",
-    "example_jp": "きょう　がっこうを　やすんだんです。かぜを　ひいたんです",
-    "example_en": "The thing is I skipped school today. I caught a cold, you see"
-  },
-  "practice": "Write 5 explanatory sentences using 〜んです about why you did or didn't do something.",
-  "tip": "〜んです is incredibly common in natural Japanese speech but rarely in textbooks. Mastering it makes you sound much more natural!"
-}, {
-  "day": 174,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 28,
-  "title": "〜そうです: Hearsay vs Appearance",
-  "intro": "Two meanings: 〜そうです① = I heard that ~ (hearsay). 〜そうです② = looks like ~ / seems ~ (appearance).",
-  "type": "verbs",
-  "chars": [["あめがふりそうです", "it looks like it will rain (appearance)"], ["かれはげんきそうです", "he looks healthy (appearance)"], ["あのレストランはおいしいそうです", "I heard that restaurant is good (hearsay)"], ["にほんごはむずかしいそうです", "I heard Japanese is difficult (hearsay)"], ["かなしそうです", "looks sad (appearance)"]],
-  "vocab": [["〜そうです (appearance)", "〜そうです", "looks like ~ / seems ~"], ["〜そうです (hearsay)", "〜そうです", "I heard that ~"], ["〜らしいです", "〜らしいです", "apparently ~ / I heard that ~"], ["〜ようです", "〜ようです", "it seems that ~"], ["〜みたいです", "〜みたいです", "looks like ~ (casual)"]],
-  "grammar": {
-    "pattern": "〜そうです (both)",
-    "meaning": "looks like ~ / I heard that ~",
-    "example_jp": "そとは　さむそうです。コートを　きていったほうが　いいですよ",
-    "example_en": "It looks cold outside. You'd better wear a coat"
-  },
-  "practice": "Write 3 appearance 〜そうです and 3 hearsay 〜そうです sentences.",
-  "tip": "KEY: Appearance そうです uses verb/adj STEM + そうです (おいし+そう). Hearsay そうです uses PLAIN FORM + そうです (おいしい+そうです). Watch the form!"
-}, {
-  "day": 175,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 28,
-  "title": "〜すぎる: Too Much",
-  "intro": "〜すぎます = too much ~, do ~ too much.",
-  "type": "verbs",
-  "chars": [["たべすぎます", "eat too much"], ["のみすぎます", "drink too much"], ["はたらきすぎます", "work too much"], ["たかすぎます", "too expensive (adj)"], ["むずかしすぎます", "too difficult (adj)"]],
-  "vocab": [["〜すぎて", "〜すぎて", "because of doing ~ too much"], ["〜すぎないように", "〜すぎないように", "so as not to ~ too much"], ["ほどほどに", "ほどほどに", "in moderation"], ["やりすぎ", "やりすぎ", "overdoing it"], ["〜すぎた", "〜すぎた", "did ~ too much (past)"]],
-  "grammar": {
-    "pattern": "〜すぎます",
-    "meaning": "too much ~",
-    "example_jp": "きのうは　たべすぎて、おなかが　いたいです",
-    "example_en": "I ate too much yesterday and my stomach hurts"
-  },
-  "practice": "Write 5 sentences using すぎます for actions or adjectives.",
-  "tip": "すぎます: verb stem + すぎます (たべ+すぎ), i-adj stem + すぎます (むずかし+すぎ), na-adj + すぎます (しずか+すぎ). Applies to all word types!"
-}, {
-  "day": 176,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 29,
-  "title": "〜やすい・〜にくい: Easy/Hard to Do",
-  "intro": "〜やすいです = easy to do. 〜にくいです = hard to do.",
-  "type": "verbs",
-  "chars": [["たべやすいです", "easy to eat"], ["わかりやすいです", "easy to understand"], ["つかいやすいです", "easy to use"], ["よみにくいです", "hard to read"], ["はなしにくいです", "hard to speak"]],
-  "vocab": [["〜やすい", "〜やすい", "easy to ~ / tends to ~"], ["〜にくい", "〜にくい", "hard to ~ / difficult to ~"], ["べんり(な)", "べんり(な)", "convenient"], ["〜しやすい　かんきょう", "〜しやすい　かんきょう", "environment easy to ~"], ["〜しにくい", "〜しにくい", "hard to do ~"]],
-  "grammar": {
-    "pattern": "〜やすいです / 〜にくいです",
-    "meaning": "easy/hard to ~",
-    "example_jp": "このほんは　わかりやすくて、べんきょうしやすいです",
-    "example_en": "This book is easy to understand and easy to study from"
-  },
-  "practice": "Rate 5 things in your life: easy or hard to do?",
-  "tip": "やすい and にくい attach to the verb STEM (before ます): たべ+やすい, はなし+にくい. Very productive pattern in Japanese!"
-}, {
-  "day": 177,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 29,
-  "title": "〜ほうがいい: Should / Better To",
-  "intro": "〜ほうがいい = it would be better to ~. Used for advice and recommendations.",
-  "type": "verbs",
-  "chars": [["いったほうがいいです", "you should go"], ["たべたほうがいいです", "you should eat"], ["ねたほうがいいです", "you should sleep"], ["いかないほうがいいです", "you should not go"], ["たべないほうがいいです", "you should not eat"]],
-  "vocab": [["〜ほうがいい", "〜ほうがいい", "had better ~ / should ~"], ["〜ほうがいいですよ", "〜ほうがいいですよ", "you should ~, you know"], ["〜ほうがよかった", "〜ほうがよかった", "would have been better to ~"], ["アドバイス", "アドバイス", "advice"], ["おすすめ", "おすすめ", "recommendation"]],
-  "grammar": {
-    "pattern": "〜ほうがいいですよ",
-    "meaning": "You should ~ (advice)",
-    "example_jp": "かぜなら、はやく　ねたほうが　いいですよ",
-    "example_en": "If you have a cold, you should sleep early"
-  },
-  "practice": "Give advice to 5 different situations using ほうがいい.",
-  "tip": "Positive advice: た-form + ほうがいい (did better to ~). Negative advice: ない-form + ほうがいい (not doing better). Both are common advice patterns!"
-}, {
-  "day": 178,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 29,
-  "title": "〜てみる: Try Doing",
-  "intro": "〜てみます = try doing ~. Express attempting something for the first time or experimentally.",
-  "type": "verbs",
-  "chars": [["たべてみます", "try eating"], ["いってみます", "try going"], ["はなしてみます", "try speaking"], ["つかってみます", "try using"], ["やってみます", "try doing/trying"]],
-  "vocab": [["〜てみてください", "〜てみてください", "please try ~"], ["〜てみましたか", "〜てみましたか", "have you tried ~?"], ["〜てみたいです", "〜てみたいです", "want to try ~"], ["ためしに", "ためしに", "as a trial/experiment"], ["ちょうせん", "ちょうせん", "challenge"]],
-  "grammar": {
-    "pattern": "〜てみます",
-    "meaning": "I'll try ~ing",
-    "example_jp": "にほんのたべものを　なんでも　たべてみます",
-    "example_en": "I'll try eating anything Japanese"
-  },
-  "practice": "List 5 things you want to try doing in Japan.",
-  "tip": "〜てみる adds a nuance of 'try and see what happens' — it's experimental and exploratory. Great for expressing curiosity and adventure!"
-}, {
-  "day": 179,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 29,
-  "title": "〜てしまう: Accidentally/Completely",
-  "intro": "〜てしまいます = end up doing ~ (accidentally or completely finished, sometimes regret).",
-  "type": "verbs",
-  "chars": [["たべてしまいました", "ended up eating (all of it)"], ["わすれてしまいました", "ended up forgetting"], ["なくしてしまいました", "ended up losing"], ["おくれてしまいました", "ended up being late"], ["いってしまいました", "(they) went away (completely)"]],
-  "vocab": [["〜てしまった", "〜てしまった", "ended up ~ing (plain, with regret)"], ["〜ちゃった", "〜ちゃった", "ended up ~ing (casual contraction)"], ["うっかり", "うっかり", "carelessly/accidentally"], ["のこらず", "のこらず", "without leaving any"], ["ぜんぶ", "ぜんぶ", "all of it"]],
-  "grammar": {
-    "pattern": "〜てしまいました",
-    "meaning": "ended up ~ing (accidental/complete)",
-    "example_jp": "さいふを　わすれてしまいました",
-    "example_en": "I ended up forgetting my wallet"
-  },
-  "practice": "Describe 5 accidental things using てしまいました.",
-  "tip": "Casual: 〜てしまった → 〜ちゃった (verbal contraction). わすれてしまった → わすれちゃった. Very common in everyday speech!"
-}, {
-  "day": 180,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 30,
-  "title": "〜させる: Causative",
-  "intro": "〜させます = make/let ~ do ~. Used when someone causes or allows another to do something.",
-  "type": "verbs",
-  "chars": [["たべさせます", "make/let eat"], ["いかせます", "make/let go"], ["はなさせます", "make/let speak"], ["べんきょうさせます", "make/let study"], ["やすませます", "make/let rest"]],
-  "vocab": [["〜させてください", "〜させてください", "please let me ~"], ["〜させてもらえますか", "〜させてもらえますか", "may I be allowed to ~?"], ["むりやり", "むりやり", "by force"], ["じゆうに", "じゆうに", "freely"], ["〜させられる", "〜させられる", "be made to ~ (passive causative)"]],
-  "grammar": {
-    "pattern": "〜させてください",
-    "meaning": "Please let me ~",
-    "example_jp": "すこし　かんがえさせてください",
-    "example_en": "Please let me think for a moment"
-  },
-  "practice": "Write: 3 things you want to be allowed to do (させてください) and 3 you'd make others do.",
-  "tip": "させてください is a very polite way to ask permission to do something yourself. More formal than てもいいですか."
-}, {
-  "day": 181,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 30,
-  "title": "〜られる: Passive Form",
-  "intro": "Passive form: RU-verbs: drop る + られる. U-verbs: あ-row + れる.",
-  "type": "verbs",
-  "chars": [["たべられます", "is eaten / (I) can eat"], ["みられます", "is seen / (I) can see"], ["いわれます", "is said / (I) am told"], ["よばれます", "is called / (I) am called"], ["しかられます", "is scolded / (I) am scolded"]],
-  "vocab": [["〜にいわれました", "〜にいわれました", "was told by ~"], ["〜にしかられました", "〜にしかられました", "was scolded by ~"], ["〜にほめられました", "〜にほめられました", "was praised by ~"], ["〜によって", "〜によって", "by ~ (passive agent)"], ["めいわく", "めいわく", "nuisance/trouble"]],
-  "grammar": {
-    "pattern": "〜に　〜られました",
-    "meaning": "was ~ed by ~",
-    "example_jp": "せんせいに　ほめられました",
-    "example_en": "I was praised by the teacher"
-  },
-  "practice": "Write 5 passive sentences (something happened to you).",
-  "tip": "Japanese passive is often used for 'suffering passive' — something unpleasant happened TO you: あめにふられた (got rained on). Very common in expressions of inconvenience!"
-}, {
-  "day": 182,
-  "phaseNum": 5,
-  "phaseName": "Verbs",
-  "week": 30,
-  "title": "Verb Phase Final Review",
-  "intro": "Complete review of Phase 5 with JLPT-style practice.",
-  "type": "verbs",
-  "chars": [],
-  "vocab": [["て-form uses", "て-form uses", "request/sequence/progressive/permission"], ["たい/ほしい", "たい/ほしい", "want to do / want (thing)"], ["てもいい/てはいけない", "てもいい/てはいけない", "may/must not"], ["なければならない/なくてもいい", "なければならない/なくてもいい", "must/don't have to"], ["たら/ば/と/なら", "たら/ば/と/なら", "4 conditionals"]],
-  "grammar": {
-    "pattern": "Phase 5 complete review",
-    "meaning": "All verb forms",
-    "example_jp": "にほんごが　はなせるように　なりたいです。もっとべんきょうしなければなりません",
-    "example_en": "I want to become able to speak Japanese. I must study more"
-  },
-  "practice": "Write a paragraph about your Japanese learning journey using 5+ verb forms from Phase 5.",
-  "tip": "Incredible progress! You've now covered all the major verb patterns for N5 (and beyond). Phase 6 covers the remaining key grammar points!"
-}, {
-  "day": 183,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 27,
-  "title": "〜から: Because",
-  "intro": "から after a plain/polite form = because ~. Gives the reason for something.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜から", "〜から", "because ~ (reason)"], ["だから", "だから", "therefore / that's why"], ["なぜなら", "なぜなら", "the reason is that"], ["〜ので", "〜ので", "because ~ (softer/formal)"], ["りゆう", "りゆう", "reason"]],
-  "grammar": {
-    "pattern": "〜から",
-    "meaning": "because ~",
-    "example_jp": "あめだから、いえにいます",
-    "example_en": "Because it's raining, I'm home"
-  },
-  "practice": "Write 5 reason sentences: why you like Japanese, why you study, why you are tired.",
-  "tip": "〜から is direct. 〜ので is softer and more formal. In polite writing and formal situations, ので is preferred."
-}, {
-  "day": 184,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 27,
-  "title": "〜ので: Because (Soft)",
-  "intro": "ので is a softer, more polite reason marker than から. Widely used in formal situations.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ので", "〜ので", "because ~ (formal/soft)"], ["じじょう", "じじょう", "circumstances"], ["しかたない", "しかたない", "can't be helped"], ["〜ためです", "〜ためです", "it is because of ~"], ["もうしわけない", "もうしわけない", "I'm very sorry"]],
-  "grammar": {
-    "pattern": "〜ので、〜ます",
-    "meaning": "Because ~, (I) ~",
-    "example_jp": "ちょっとぐあいがわるいので、きょうはやすみます",
-    "example_en": "Because I'm not feeling well, I'll rest today"
-  },
-  "practice": "Rewrite 5 から sentences as ので sentences. Notice how the tone changes.",
-  "tip": "Rule: plain form + ので (ていねいなので), but な-adj/noun + なので (しずかなので, がくせいなので). Don't use だので!"
-}, {
-  "day": 185,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 27,
-  "title": "〜し: Multiple Reasons",
-  "intro": "〜し = and (listing multiple reasons). More complete than から.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜し、〜し", "〜し、〜し", "not only ~, but also ~ (reasons)"], ["それに", "それに", "moreover / in addition"], ["おまけに", "おまけに", "on top of that"], ["〜うえに", "〜うえに", "in addition to ~"], ["いろいろと", "いろいろと", "in various ways"]],
-  "grammar": {
-    "pattern": "〜し、〜し、〜です",
-    "meaning": "not only ~ but also ~, so ~",
-    "example_jp": "にほんごはおもしろいし、たのしいし、べんりです",
-    "example_en": "Japanese is interesting, fun, and useful"
-  },
-  "practice": "List 3 reasons why you like something using 〜し〜し.",
-  "tip": "〜し is perfect for persuasion and listing multiple supporting reasons. Sounds more natural than just stacking から sentences!"
-}, {
-  "day": 186,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 27,
-  "title": "〜が・〜けど: But/However",
-  "intro": "が and けど both mean 'but/however'. が is more formal; けど (keredo) is casual.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜が", "〜が", "but / however (formal)"], ["〜けど", "〜けど", "but / though (casual)"], ["〜でも", "〜でも", "but / however (start of sentence)"], ["〜しかし", "〜しかし", "however (formal)"], ["〜ところが", "〜ところが", "but (unexpected result)"]],
-  "grammar": {
-    "pattern": "〜ですが、〜です",
-    "meaning": "~ but ~",
-    "example_jp": "にほんごはむずかしいですが、おもしろいです",
-    "example_en": "Japanese is difficult, but it's interesting"
-  },
-  "practice": "Write 5 sentences with contrast using が or けど.",
-  "tip": "〜が and 〜けど can also soften requests and lead into an ask: すみませんが、〜してもらえますか (Excuse me, but could you ~?)"
-}, {
-  "day": 187,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 27,
-  "title": "〜のに: Although (Unexpected)",
-  "intro": "のに = although / even though (expresses surprise or disappointment at an unexpected outcome).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜のに", "〜のに", "although ~ / even though ~"], ["〜にもかかわらず", "〜にもかかわらず", "despite ~ (formal)"], ["〜はずなのに", "〜はずなのに", "should be ~ but..."], ["がっかり", "がっかり", "disappointed"], ["きたいはずれ", "きたいはずれ", "letting down expectations"]],
-  "grammar": {
-    "pattern": "〜のに、〜ます",
-    "meaning": "although ~, ~ (unexpected)",
-    "example_jp": "べんきょうしたのに、しけんにおちました",
-    "example_en": "Even though I studied, I failed the test"
-  },
-  "practice": "Express 3 disappointments or surprises using のに.",
-  "tip": "のに carries an emotional tone of complaint or surprise. が/けど are neutral contrast; のに has feeling baked in!"
-}, {
-  "day": 188,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 27,
-  "title": "〜でも: Even / But",
-  "intro": "でも = but (sentence-initial). Also: even ~ / at least ~.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["でも", "でも", "but / however (starts sentence)"], ["〜でも", "〜でも", "even ~ (after noun)"], ["どんなことでも", "どんなことでも", "anything at all"], ["だれでも", "だれでも", "anyone at all"], ["いつでも", "いつでも", "anytime"]],
-  "grammar": {
-    "pattern": "でも、〜です",
-    "meaning": "But, ~",
-    "example_jp": "むずかしいです。でも、たのしいです",
-    "example_en": "It's difficult. But it's fun"
-  },
-  "practice": "Write 5 sentences starting with でも to express contrast.",
-  "tip": "〜でも (attached to word) = 'even': だれでも = anyone, なんでも = anything, どこでも = anywhere. Very useful for inclusive expressions!"
-}, {
-  "day": 189,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 27,
-  "title": "〜ましょう・〜ませんか: Suggestions",
-  "intro": "〜ましょう = Let's ~. 〜ませんか = Shall we ~? / Won't you ~?",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ましょう", "〜ましょう", "let's ~ (invitation/proposal)"], ["〜ましょうか", "〜ましょうか", "shall I / shall we ~?"], ["〜ませんか", "〜ませんか", "won't you ~? / how about ~?"], ["さそう", "さそう", "invite"], ["ていあん", "ていあん", "suggestion/proposal"]],
-  "grammar": {
-    "pattern": "〜ましょう / 〜ませんか",
-    "meaning": "Let's ~ / Shall we ~?",
-    "example_jp": "いっしょに　ひるごはんを　たべませんか",
-    "example_en": "Won't you eat lunch with me?"
-  },
-  "practice": "Invite someone to: eat lunch, study Japanese, watch a movie, go shopping, take a walk.",
-  "tip": "ましょう is more assertive (Let's go!). ませんか is softer and more polite (Wouldn't you like to go?). Japanese culture tends to prefer the softer option!"
-}, {
-  "day": 190,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 28,
-  "title": "〜てほしい: Want Someone Else to Do",
-  "intro": "〜てほしいです = I want (someone else) to ~. Different from たい (MY desire).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜てほしい", "〜てほしい", "want (them) to ~"], ["〜てほしくない", "〜てほしくない", "don't want (them) to ~"], ["〜てほしかった", "〜てほしかった", "wanted (them) to ~"], ["おねがい", "おねがい", "please / request"], ["きたい", "きたい", "expectation"]],
-  "grammar": {
-    "pattern": "〜に　〜てほしいです",
-    "meaning": "I want ~ to ~",
-    "example_jp": "せんせいに　もっと　ゆっくり　はなしてほしいです",
-    "example_en": "I want the teacher to speak more slowly"
-  },
-  "practice": "Write 5 things you want others to do for you using てほしい.",
-  "tip": "たい = I want to do ~ (my desire). てほしい = I want someone else to do ~ (desire about others' actions). Critical distinction!"
-}, {
-  "day": 191,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 28,
-  "title": "〜とき: When (Time)",
-  "intro": "〜とき = when / at the time of ~. Marks a specific time or condition.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜とき", "〜とき", "when ~ / at the time of ~"], ["こどものとき", "こどものとき", "when I was a child"], ["べんきょうするとき", "べんきょうするとき", "when studying"], ["こまったとき", "こまったとき", "when in trouble"], ["〜ときに", "〜ときに", "at the time when ~"]],
-  "grammar": {
-    "pattern": "〜とき、〜ます",
-    "meaning": "When ~, (I) ~",
-    "example_jp": "にほんにいくとき、にほんごではなしたいです",
-    "example_en": "When I go to Japan, I want to speak in Japanese"
-  },
-  "practice": "Write 5 sentences using とき: childhood memories, daily habits, future plans.",
-  "tip": "とき vs たら: とき = 'at the time when' (describes circumstances). たら = 'when/if' (conditional, triggers next action). Subtle but important!"
-}, {
-  "day": 192,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 28,
-  "title": "〜ために: In Order To / For",
-  "intro": "〜ために = in order to ~ / for the sake of ~.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ために", "〜ために", "in order to ~ / for the sake of ~"], ["もくてき", "もくてき", "purpose/goal"], ["〜のために", "〜のために", "for the sake of ~"], ["〜ようにするために", "〜ようにするために", "in order to be able to ~"], ["どりょく", "どりょく", "effort"]],
-  "grammar": {
-    "pattern": "〜ために、〜ます",
-    "meaning": "In order to ~, (I) ~",
-    "example_jp": "にほんごをはなせるようになるために、まいにちべんきょうします",
-    "example_en": "In order to be able to speak Japanese, I study every day"
-  },
-  "practice": "Write your top 3 life goals and what you do each day to achieve them using ために.",
-  "tip": "〜ために expresses PURPOSE. 〜から/ので expresses REASON. Distinction: ために looks forward (goal), から/ので looks backward (cause)."
-}, {
-  "day": 193,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 28,
-  "title": "〜ように: So That / In Order To",
-  "intro": "〜ようにします = make sure to ~, try to ~. 〜ようになります = come to be able to ~.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ようになりました", "〜ようになりました", "came to be able to ~ (gradual change)"], ["〜ようにしています", "〜ようにしています", "I make a point of ~ing"], ["〜できるようになる", "〜できるようになる", "become able to ~"], ["〜ないようにする", "〜ないようにする", "try not to ~"], ["せいちょう", "せいちょう", "growth"]],
-  "grammar": {
-    "pattern": "〜ように　なりました",
-    "meaning": "came to be able to ~",
-    "example_jp": "にほんごで　はなせるように　なりました",
-    "example_en": "I've come to be able to speak in Japanese"
-  },
-  "practice": "Write 3 things you've come to be able to do (ようになりました) since starting to study Japanese.",
-  "tip": "〜ようになる expresses GRADUAL CHANGE — perfect for describing learning progress! This is a great pattern to use in your journal."
-}, {
-  "day": 194,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 28,
-  "title": "〜という: Called / Named",
-  "intro": "〜という = called ~ / that ~ (quoting or naming).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜という", "〜という", "called ~ / named ~"], ["〜ということ", "〜ということ", "the fact that ~"], ["〜という　こと", "〜という　こと", "the thing called ~"], ["〜とは", "〜とは", "what is ~? / as for ~"], ["〜の　いみ", "〜の　いみ", "the meaning of ~"]],
-  "grammar": {
-    "pattern": "〜という　Noun",
-    "meaning": "a Noun called ~",
-    "example_jp": "「さくら」という　ことばを　しっていますか",
-    "example_en": "Do you know the word called 'sakura'?"
-  },
-  "practice": "Use 〜という to explain Japanese words or concepts you've learned.",
-  "tip": "〜という is extremely useful for talking about Japanese words and culture: 〜というのはどういう意味ですか (What does ~ mean?)"
-}, {
-  "day": 195,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 28,
-  "title": "〜のは・〜のが・〜のを: Nominaliser の",
-  "intro": "の turns verb phrases into nouns (nominaliser).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜のは　〜です", "〜のは　〜です", "The ~ of doing ~ is ~"], ["〜のが　すき", "〜のが　すき", "like ~ing"], ["〜のが　とくい", "〜のが　とくい", "good at ~ing"], ["〜のを　みた", "〜のを　みた", "saw ~ doing ~"], ["〜のが　わかる", "〜のが　わかる", "understand that ~"]],
-  "grammar": {
-    "pattern": "〜のが　すきです",
-    "meaning": "I like ~ing",
-    "example_jp": "にほんごをべんきょうするのが　すきです",
-    "example_en": "I like studying Japanese"
-  },
-  "practice": "Write: 3 things you like doing, 3 things you're good at, using のがすき/とくい.",
-  "tip": "の nominaliser vs こと nominaliser: のが is used with perception verbs (みる、きく) and likes. こと is used with ことができる, knowing facts, etc. Both are needed!"
-}, {
-  "day": 196,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 28,
-  "title": "〜ようだ・〜みたいだ: Seems Like",
-  "intro": "〜ようです = it seems that ~ (formal). 〜みたいです = seems like ~ (casual).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ようです", "〜ようです", "it seems that ~ (formal)"], ["〜みたいです", "〜みたいです", "seems like ~ (casual)"], ["〜らしいです", "〜らしいです", "apparently ~ / I heard ~"], ["〜そうです", "〜そうです", "looks like / I heard"], ["〜かもしれません", "〜かもしれません", "might be ~"]],
-  "grammar": {
-    "pattern": "〜みたいです / 〜ようです",
-    "meaning": "seems like / it appears that",
-    "example_jp": "かれは　にほんじんみたいです",
-    "example_en": "He seems to be Japanese"
-  },
-  "practice": "Write 5 observations using みたいです and ようです about things you notice around you.",
-  "tip": "The spectrum from certain to uncertain: です (certain) → ようです/みたいです (seems) → でしょう (probably) → かもしれません (might) → はずがない (can't be)"
-}, {
-  "day": 197,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 29,
-  "title": "〜はずです: Should Be / Expected",
-  "intro": "〜はずです = should be ~ / expected to ~. Based on reasoning or expectation.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜はずです", "〜はずです", "should be ~ / expected to ~"], ["〜はずがありません", "〜はずがありません", "can't possibly be ~"], ["〜はずだった", "〜はずだった", "was supposed to ~"], ["よてい", "よてい", "plan/schedule"], ["みこみ", "みこみ", "expectation/hope"]],
-  "grammar": {
-    "pattern": "〜はずです",
-    "meaning": "should be ~ (based on expectation)",
-    "example_jp": "かれは　もうすぐ　くるはずです",
-    "example_en": "He should be coming soon"
-  },
-  "practice": "Write 5 expectations using はずです — what should happen today/this week?",
-  "tip": "はずだった (was supposed to ~) expresses disappointment when things didn't go as expected: くるはずだったのに、こなかった (Was supposed to come but didn't)"
-}, {
-  "day": 198,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 29,
-  "title": "〜かどうか: Whether or Not",
-  "intro": "〜かどうか = whether or not ~. Used with embedded questions.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜かどうかわかりません", "〜かどうかわかりません", "I don't know whether ~"], ["〜かどうかきいてみます", "〜かどうかきいてみます", "I'll ask whether ~"], ["〜かどうかかんがえています", "〜かどうかかんがえています", "I'm thinking about whether ~"], ["はんだん", "はんだん", "judgment/decision"], ["けってい", "けってい", "decision"]],
-  "grammar": {
-    "pattern": "〜かどうか、わかりません",
-    "meaning": "I don't know whether ~",
-    "example_jp": "あしたあめがふるかどうか、わかりません",
-    "example_en": "I don't know whether it will rain tomorrow"
-  },
-  "practice": "Write 5 uncertainties using かどうか.",
-  "tip": "〜かどうか embeds a yes/no question into another sentence. 〜かを embeds a wh-question: どこにいったか (where they went). Both essential for indirect speech!"
-}, {
-  "day": 199,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 29,
-  "title": "〜まま: As Is / Unchanged State",
-  "intro": "〜まま = as is / in that state (unchanged). Describes maintaining a state.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜たまま", "〜たまま", "while still ~ / having done ~ and staying that way"], ["〜ないまま", "〜ないまま", "without ~ing / staying in un-~ed state"], ["そのまま", "そのまま", "as is / just like that"], ["〜つづける", "〜つづける", "continue to ~"], ["かわらず", "かわらず", "unchanged"]],
-  "grammar": {
-    "pattern": "〜たまま",
-    "meaning": "still ~ / having done ~ and left it that way",
-    "example_jp": "くつを　はいたまま　はいってしまいました",
-    "example_en": "I entered while still wearing my shoes"
-  },
-  "practice": "Write 3 まま sentences about states that were left unchanged.",
-  "tip": "〜まま: めをとじたまま (with eyes still closed), くつをはいたまま (with shoes still on). Describes not changing a state — very natural in Japanese!"
-}, {
-  "day": 200,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 29,
-  "title": "Grammar Checkpoint: Days 183-199",
-  "intro": "Review of all grammar from the last 17 days.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜から・ので", "〜から・ので", "because"], ["〜が・けど", "〜が・けど", "but"], ["〜ために", "〜ために", "in order to"], ["〜ように", "〜ように", "so that/come to"], ["〜はずです", "〜はずです", "should be"]],
-  "grammar": {
-    "pattern": "Review: reason, contrast, purpose",
-    "meaning": "Core linking grammar",
-    "example_jp": "にほんごがはなせるようになるために、まいにちべんきょうしています。むずかしいですが、たのしいです",
-    "example_en": "I study every day to be able to speak Japanese. It's difficult, but fun"
-  },
-  "practice": "Write a paragraph about your Japanese study using at least 5 grammar patterns from days 183-199.",
-  "tip": "Midpoint of Phase 6! You're building the connective tissue of Japanese — the grammar that links ideas into natural, flowing speech."
-}, {
-  "day": 201,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 29,
-  "title": "〜ていただけますか: Very Polite Request",
-  "intro": "The most polite way to request — for formal settings and seniors.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ていただけますか", "〜ていただけますか", "would you kindly ~?"], ["〜てくださいませんか", "〜てくださいませんか", "would you please ~?"], ["〜てもらえますか", "〜てもらえますか", "would you do ~ for me?"], ["ていねいご", "ていねいご", "polite language"], ["けいご", "けいご", "honorific language"]],
-  "grammar": {
-    "pattern": "〜ていただけますか",
-    "meaning": "Would you kindly ~?",
-    "example_jp": "もういちど　おっしゃっていただけますか",
-    "example_en": "Would you kindly say that again?"
-  },
-  "practice": "Write 5 very polite requests for hotel, hospital, office situations.",
-  "tip": "Politeness ladder: してください < してもらえますか < していただけますか. Use the last for seniors and formal occasions!"
-}, {
-  "day": 202,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 29,
-  "title": "〜ようにしてください: Please Make Sure",
-  "intro": "Please make sure to ~. Stronger than just ください.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ようにしてください", "〜ようにしてください", "please make sure to ~"], ["〜ないようにしてください", "〜ないようにしてください", "please make sure not to ~"], ["きをつける", "きをつける", "be careful"], ["まもる", "まもる", "follow rules"], ["こころがける", "こころがける", "keep in mind"]],
-  "grammar": {
-    "pattern": "〜ように　してください",
-    "meaning": "Please make sure to ~",
-    "example_jp": "まいにち　くすりを　のむように　してください",
-    "example_en": "Please make sure to take your medicine every day"
-  },
-  "practice": "Write 5 careful instructions using ようにしてください.",
-  "tip": "〜ようにする (make a point of) vs 〜ようになる (come to be able to). Both essential patterns for expressing habits and changes!"
-}, {
-  "day": 203,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 29,
-  "title": "〜までに: By (Deadline)",
-  "intro": "〜まで = until. 〜までに = by (deadline). Critical distinction!",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜まで", "〜まで", "until ~"], ["〜までに", "〜までに", "by ~ (deadline)"], ["しめきり", "しめきり", "deadline"], ["きげん", "きげん", "time limit"], ["かんりょう", "かんりょう", "completion"]],
-  "grammar": {
-    "pattern": "〜までに　〜ます",
-    "meaning": "will ~ by ~",
-    "example_jp": "かようびまでに　しゅくだいを　だします",
-    "example_en": "I will submit homework by Tuesday"
-  },
-  "practice": "Write 5 deadline sentences: what will you do by when?",
-  "tip": "まで = duration (until 5 o'clock). までに = deadline (by 5 o'clock). One particle changes the meaning entirely!"
-}, {
-  "day": 204,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 30,
-  "title": "〜たばかりです: Just Did",
-  "intro": "〜たばかり = just completed an action (very recently).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜たばかりです", "〜たばかりです", "just ~ed"], ["ちょうど", "ちょうど", "just now / exactly"], ["さっき", "さっき", "a moment ago"], ["〜したところです", "〜したところです", "just finished doing"], ["まだ〜ていません", "まだ〜ていません", "haven't done yet"]],
-  "grammar": {
-    "pattern": "〜たばかりです",
-    "meaning": "just ~ed",
-    "example_jp": "にほんに　きたばかりです",
-    "example_en": "I just arrived in Japan"
-  },
-  "practice": "Write 5 'just did' sentences using たばかりです.",
-  "tip": "たばかり = very recently completed. Perfect for first encounters: にほんごをべんきょうしはじめたばかりです (I just started studying Japanese)!"
-}, {
-  "day": 205,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 30,
-  "title": "〜だけ vs 〜しか〜ない: Only",
-  "intro": "だけ = only (neutral). しか〜ない = only/nothing but (emphatic, with negative).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜だけです", "〜だけです", "only ~ (neutral)"], ["〜しか〜ない", "〜しか〜ない", "only ~ (emphatic negative)"], ["それだけ", "それだけ", "that's all"], ["〜のみ", "〜のみ", "only (formal)"], ["ほかには", "ほかには", "other than that"]],
-  "grammar": {
-    "pattern": "〜だけ / 〜しか〜ない",
-    "meaning": "only ~ (neutral/emphatic)",
-    "example_jp": "みずだけのみます。/みずしかありません",
-    "example_en": "I'll only drink water. / There's only water (nothing else)"
-  },
-  "practice": "Write 5 sentences with だけ and 5 with しか〜ない, noting the difference in nuance.",
-  "tip": "KEY: しか ALWAYS takes negative verb: 〜しか〜ない. The emphasis is built into the negative: there's ONLY this, NOTHING else!"
-}, {
-  "day": 206,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 30,
-  "title": "〜も: Quantity Emphasis",
-  "intro": "も after numbers = 'as many as'. も with negation = 'not even'.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜もあります", "〜もあります", "there are as many as ~"], ["ひとつもない", "ひとつもない", "not even one"], ["だれも〜ない", "だれも〜ない", "nobody at all"], ["なにも〜ない", "なにも〜ない", "nothing at all"], ["どこも〜ない", "どこも〜ない", "nowhere at all"]],
-  "grammar": {
-    "pattern": "〜も　〜ません",
-    "meaning": "not even ~ (emphasis)",
-    "example_jp": "ひとつも　わかりません",
-    "example_en": "I don't understand even one thing"
-  },
-  "practice": "Write 3 'surprising amounts' and 3 'complete negation' sentences using も.",
-  "tip": "Total negation family: だれも〜ない, なにも〜ない, どこも〜ない, いつも〜ない. Learn them together as a set!"
-}, {
-  "day": 207,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 30,
-  "title": "〜ごろ・くらい・ほど: Approximation",
-  "intro": "ごろ = around (time). くらい/ほど = approximately (amount, degree).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ごろ", "〜ごろ", "around ~ (time only)"], ["〜くらい", "〜くらい", "about ~ (amount, casual)"], ["〜ほど", "〜ほど", "about ~ (formal, extent)"], ["だいたい", "だいたい", "approximately"], ["〜ぐらい", "〜ぐらい", "about ~ (variant of くらい)"]],
-  "grammar": {
-    "pattern": "〜ごろ / 〜くらい",
-    "meaning": "around ~ / approximately ~",
-    "example_jp": "さんじごろに　きます。いちじかんくらいかかります",
-    "example_en": "I'll come around 3. It takes about 1 hour"
-  },
-  "practice": "Write 5 approximate expressions: times with ごろ, amounts with くらい.",
-  "tip": "ごろ is for TIME only. くらい/ほど are for AMOUNTS, DISTANCES, and EXTENTS. Mixing them is a common mistake!"
-}, {
-  "day": 208,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "〜おかげで: Thanks to (Positive)",
-  "intro": "〜おかげで = thanks to ~ (used when the result is POSITIVE).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜おかげで", "〜おかげで", "thanks to ~"], ["おかげさまで", "おかげさまで", "thanks to you / thanks to everyone"], ["〜のおかげ", "〜のおかげ", "owing to ~"], ["かんしゃ", "かんしゃ", "gratitude"], ["おせわになりました", "おせわになりました", "thank you for your care/help"]],
-  "grammar": {
-    "pattern": "〜おかげで、〜できました",
-    "meaning": "Thanks to ~, I was able to ~",
-    "example_jp": "みなさんの　おかげで　ごうかくしました",
-    "example_en": "Thanks to everyone, I passed"
-  },
-  "practice": "Write 3 things you're grateful for using おかげで.",
-  "tip": "おかげで = good result. せいで = bad result. Always match the cause word to the outcome tone: positive → おかげで, negative → せいで!"
-}, {
-  "day": 209,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "〜せいで: Because of (Negative)",
-  "intro": "〜せいで = because of ~ (leading to a BAD result).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜せいで", "〜せいで", "because of ~ (bad)"], ["〜のせいにする", "〜のせいにする", "blame ~ for"], ["せきにん", "せきにん", "responsibility"], ["もんく", "もんく", "complaint"], ["あやまる", "あやまる", "apologise"]],
-  "grammar": {
-    "pattern": "〜のせいで、〜なりました",
-    "meaning": "Because of ~, ~ happened (bad)",
-    "example_jp": "かれの　せいで　おくれました",
-    "example_en": "Because of him, I was late"
-  },
-  "practice": "Write 3 sentences expressing blame or negative outcomes using せいで.",
-  "tip": "おかげで (positive result) vs せいで (negative result). Choosing the wrong one is a significant social mistake — be careful!"
-}, {
-  "day": 210,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "〜ことにする vs 〜ことになる",
-  "intro": "ことにする = I decided. ことになる = it has been decided (external decision).",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜ことにしました", "〜ことにしました", "I decided to ~"], ["〜ことになりました", "〜ことになりました", "it has been decided that ~ (external)"], ["〜ことにしています", "〜ことにしています", "I have a policy of ~"], ["けつだん", "けつだん", "decision"], ["さだめられた", "さだめられた", "determined/fixed"]],
-  "grammar": {
-    "pattern": "〜ことにした / 〜ことになった",
-    "meaning": "decided (self) / was decided (external)",
-    "example_jp": "にほんにいくことにしました。来年日本に行くことになりました",
-    "example_en": "I decided to go to Japan. / It was decided I'll go to Japan next year"
-  },
-  "practice": "Write 3 personal decisions (ことにした) and 3 external decisions (ことになった).",
-  "tip": "ことにした = YOUR active choice. ことになった = the situation/others decided. Very common in Japanese work settings!"
-}, {
-  "day": 211,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "〜といえば: Speaking of",
-  "intro": "といえば = speaking of ~, when it comes to ~.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["〜といえば", "〜といえば", "speaking of ~"], ["〜といったら", "〜といったら", "when it comes to ~"], ["〜で　いえば", "〜で　いえば", "in terms of ~"], ["だいひょうてき", "だいひょうてき", "representative"], ["〜の　シンボル", "〜の　シンボル", "symbol of ~"]],
-  "grammar": {
-    "pattern": "〜といえば",
-    "meaning": "speaking of ~ / when it comes to ~",
-    "example_jp": "にほんといえば、さくらですね",
-    "example_en": "When it comes to Japan, it's cherry blossoms"
-  },
-  "practice": "Use といえば to free-associate: what comes to mind when you think of Japan, food, seasons?",
-  "tip": "〜といえば triggers a topic association. Very common in conversation: A mentions something, B says といえば and brings up related topic. Natural and friendly!"
-}, {
-  "day": 212,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "Grammar & JLPT Practice: Day 29",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 213,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "Grammar & JLPT Practice: Day 30",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 214,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "Grammar & JLPT Practice: Day 31",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 215,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "Grammar & JLPT Practice: Day 32",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 216,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "Grammar & JLPT Practice: Day 33",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 217,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 31,
-  "title": "Grammar & JLPT Practice: Day 34",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 218,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 32,
-  "title": "Grammar & JLPT Practice: Day 35",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 219,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 32,
-  "title": "Grammar & JLPT Practice: Day 36",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 220,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 32,
-  "title": "Grammar & JLPT Practice: Day 37",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 221,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 32,
-  "title": "Grammar & JLPT Practice: Day 38",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 222,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 32,
-  "title": "Grammar & JLPT Practice: Day 39",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 223,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 32,
-  "title": "Grammar & JLPT Practice: Day 40",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 224,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 32,
-  "title": "Grammar & JLPT Practice: Day 41",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 225,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 33,
-  "title": "Grammar & JLPT Practice: Day 42",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 226,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 33,
-  "title": "Grammar & JLPT Practice: Day 43",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 227,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 33,
-  "title": "Grammar & JLPT Practice: Day 44",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 228,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 33,
-  "title": "Grammar & JLPT Practice: Day 45",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 229,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 33,
-  "title": "Grammar & JLPT Practice: Day 46",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 230,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 33,
-  "title": "Grammar & JLPT Practice: Day 47",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 231,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 33,
-  "title": "Grammar & JLPT Practice: Day 48",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 232,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 34,
-  "title": "Grammar & JLPT Practice: Day 49",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 233,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 34,
-  "title": "Grammar & JLPT Practice: Day 50",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 234,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 34,
-  "title": "Grammar & JLPT Practice: Day 51",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 235,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 34,
-  "title": "Grammar & JLPT Practice: Day 52",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 236,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 34,
-  "title": "Grammar & JLPT Practice: Day 53",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 237,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 34,
-  "title": "Grammar & JLPT Practice: Day 54",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 238,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 34,
-  "title": "Grammar & JLPT Practice: Day 55",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 239,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 35,
-  "title": "Grammar & JLPT Practice: Day 56",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 240,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 35,
-  "title": "Grammar & JLPT Practice: Day 57",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 241,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 35,
-  "title": "Grammar & JLPT Practice: Day 58",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 242,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 35,
-  "title": "Grammar & JLPT Practice: Day 59",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 243,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 35,
-  "title": "Grammar & JLPT Practice: Day 60",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 244,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 35,
-  "title": "Grammar & JLPT Practice: Day 61",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 245,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 35,
-  "title": "Grammar & JLPT Practice: Day 62",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 246,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 36,
-  "title": "Grammar & JLPT Practice: Day 63",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 247,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 36,
-  "title": "Grammar & JLPT Practice: Day 64",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 248,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 36,
-  "title": "Grammar & JLPT Practice: Day 65",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 249,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 36,
-  "title": "Grammar & JLPT Practice: Day 66",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 250,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 36,
-  "title": "Grammar & JLPT Practice: Day 67",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 251,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 36,
-  "title": "Grammar & JLPT Practice: Day 68",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 252,
-  "phaseNum": 6,
-  "phaseName": "Grammar",
-  "week": 36,
-  "title": "Grammar & JLPT Practice: Day 69",
-  "intro": "Daily grammar review with JLPT N5 style practice exercises.",
-  "type": "grammar",
-  "chars": [],
-  "vocab": [["もんだい1", "もんだい1", "practice question 1"], ["もんだい2", "もんだい2", "practice question 2"], ["もんだい3", "もんだい3", "practice question 3"], ["もんだい4", "もんだい4", "practice question 4"], ["もんだい5", "もんだい5", "practice question 5"]],
-  "grammar": {
-    "pattern": "JLPT N5 Grammar Practice",
-    "meaning": "Multiple choice and fill-in",
-    "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
-    "example_en": "Solve the questions and correct your mistakes"
-  },
-  "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
-  "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
-}, {
-  "day": 253,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 37,
-  "title": "Kanji: 一 (one)",
-  "intro": "Today's kanji: 一. Readings: ichi/hito. Meaning: one.",
-  "type": "kanji",
-  "chars": [["一", "ichi/hito"]],
-  "vocab": [["一", "ichi/hito", "one"], ["いちにち", "いちにち=1 day, ひとり=1 person", ""]],
-  "grammar": {
-    "pattern": "一 in words",
-    "meaning": "one",
-    "example_jp": "いちにち=1 day",
-    "example_en": "one"
-  },
-  "practice": "Write 一 20 times. Learn: いちにち=1 day, ひとり=1 person",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 一 and practice carefully!"
-}, {
-  "day": 254,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 37,
-  "title": "Kanji: 二 (two)",
-  "intro": "Today's kanji: 二. Readings: ni/futa. Meaning: two.",
-  "type": "kanji",
-  "chars": [["二", "ni/futa"]],
-  "vocab": [["二", "ni/futa", "two"], ["にほん", "にほん=Japan, ふたつ=2 things", ""]],
-  "grammar": {
-    "pattern": "二 in words",
-    "meaning": "two",
-    "example_jp": "にほん=Japan",
-    "example_en": "two"
-  },
-  "practice": "Write 二 20 times. Learn: にほん=Japan, ふたつ=2 things",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 二 and practice carefully!"
-}, {
-  "day": 255,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 37,
-  "title": "Kanji: 三 (three)",
-  "intro": "Today's kanji: 三. Readings: san/mit. Meaning: three.",
-  "type": "kanji",
-  "chars": [["三", "san/mit"]],
-  "vocab": [["三", "san/mit", "three"], ["さんにん", "さんにん=3 people", ""]],
-  "grammar": {
-    "pattern": "三 in words",
-    "meaning": "three",
-    "example_jp": "さんにん=3 people",
-    "example_en": "three"
-  },
-  "practice": "Write 三 20 times. Learn: さんにん=3 people",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 三 and practice carefully!"
-}, {
-  "day": 256,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 37,
-  "title": "Kanji: 四 (four)",
-  "intro": "Today's kanji: 四. Readings: shi/yon/yot. Meaning: four.",
-  "type": "kanji",
-  "chars": [["四", "shi/yon/yot"]],
-  "vocab": [["四", "shi/yon/yot", "four"], ["よじ", "よじ=4 o'clock, しがつ=April", ""]],
-  "grammar": {
-    "pattern": "四 in words",
-    "meaning": "four",
-    "example_jp": "よじ=4 o'clock",
-    "example_en": "four"
-  },
-  "practice": "Write 四 20 times. Learn: よじ=4 o'clock, しがつ=April",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 四 and practice carefully!"
-}, {
-  "day": 257,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 37,
-  "title": "Kanji: 五 (five)",
-  "intro": "Today's kanji: 五. Readings: go/itsu. Meaning: five.",
-  "type": "kanji",
-  "chars": [["五", "go/itsu"]],
-  "vocab": [["五", "go/itsu", "five"], ["ごにん", "ごにん=5 people", ""]],
-  "grammar": {
-    "pattern": "五 in words",
-    "meaning": "five",
-    "example_jp": "ごにん=5 people",
-    "example_en": "five"
-  },
-  "practice": "Write 五 20 times. Learn: ごにん=5 people",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 五 and practice carefully!"
-}, {
-  "day": 258,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 37,
-  "title": "Kanji: 六 (six)",
-  "intro": "Today's kanji: 六. Readings: roku/mut. Meaning: six.",
-  "type": "kanji",
-  "chars": [["六", "roku/mut"]],
-  "vocab": [["六", "roku/mut", "six"], ["ろくじ", "ろくじ=6 o'clock", ""]],
-  "grammar": {
-    "pattern": "六 in words",
-    "meaning": "six",
-    "example_jp": "ろくじ=6 o'clock",
-    "example_en": "six"
-  },
-  "practice": "Write 六 20 times. Learn: ろくじ=6 o'clock",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 六 and practice carefully!"
-}, {
-  "day": 259,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 37,
-  "title": "Kanji: 七 (seven)",
-  "intro": "Today's kanji: 七. Readings: shichi/nana. Meaning: seven.",
-  "type": "kanji",
-  "chars": [["七", "shichi/nana"]],
-  "vocab": [["七", "shichi/nana", "seven"], ["しちじ", "しちじ=7 o'clock", ""]],
-  "grammar": {
-    "pattern": "七 in words",
-    "meaning": "seven",
-    "example_jp": "しちじ=7 o'clock",
-    "example_en": "seven"
-  },
-  "practice": "Write 七 20 times. Learn: しちじ=7 o'clock",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 七 and practice carefully!"
-}, {
-  "day": 260,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 38,
-  "title": "Kanji: 八 (eight)",
-  "intro": "Today's kanji: 八. Readings: hachi/yat. Meaning: eight.",
-  "type": "kanji",
-  "chars": [["八", "hachi/yat"]],
-  "vocab": [["八", "hachi/yat", "eight"], ["はちじ", "はちじ=8 o'clock", ""]],
-  "grammar": {
-    "pattern": "八 in words",
-    "meaning": "eight",
-    "example_jp": "はちじ=8 o'clock",
-    "example_en": "eight"
-  },
-  "practice": "Write 八 20 times. Learn: はちじ=8 o'clock",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 八 and practice carefully!"
-}, {
-  "day": 261,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 38,
-  "title": "Kanji: 九 (nine)",
-  "intro": "Today's kanji: 九. Readings: ku/kyuu/kokon. Meaning: nine.",
-  "type": "kanji",
-  "chars": [["九", "ku/kyuu/kokon"]],
-  "vocab": [["九", "ku/kyuu/kokon", "nine"], ["くじ", "くじ=9 o'clock, きゅうにん=9 people", ""]],
-  "grammar": {
-    "pattern": "九 in words",
-    "meaning": "nine",
-    "example_jp": "くじ=9 o'clock",
-    "example_en": "nine"
-  },
-  "practice": "Write 九 20 times. Learn: くじ=9 o'clock, きゅうにん=9 people",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 九 and practice carefully!"
-}, {
-  "day": 262,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 38,
-  "title": "Kanji: 十 (ten)",
-  "intro": "Today's kanji: 十. Readings: juu/too. Meaning: ten.",
-  "type": "kanji",
-  "chars": [["十", "juu/too"]],
-  "vocab": [["十", "juu/too", "ten"], ["じゅうにち", "じゅうにち=10th day", ""]],
-  "grammar": {
-    "pattern": "十 in words",
-    "meaning": "ten",
-    "example_jp": "じゅうにち=10th day",
-    "example_en": "ten"
-  },
-  "practice": "Write 十 20 times. Learn: じゅうにち=10th day",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 十 and practice carefully!"
-}, {
-  "day": 263,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 38,
-  "title": "Kanji: 百 (hundred)",
-  "intro": "Today's kanji: 百. Readings: hyaku. Meaning: hundred.",
-  "type": "kanji",
-  "chars": [["百", "hyaku"]],
-  "vocab": [["百", "hyaku", "hundred"], ["ひゃくえん", "ひゃくえん=100 yen", ""]],
-  "grammar": {
-    "pattern": "百 in words",
-    "meaning": "hundred",
-    "example_jp": "ひゃくえん=100 yen",
-    "example_en": "hundred"
-  },
-  "practice": "Write 百 20 times. Learn: ひゃくえん=100 yen",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 百 and practice carefully!"
-}, {
-  "day": 264,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 38,
-  "title": "Kanji: 千 (thousand)",
-  "intro": "Today's kanji: 千. Readings: sen. Meaning: thousand.",
-  "type": "kanji",
-  "chars": [["千", "sen"]],
-  "vocab": [["千", "sen", "thousand"], ["せんえん", "せんえん=1000 yen", ""]],
-  "grammar": {
-    "pattern": "千 in words",
-    "meaning": "thousand",
-    "example_jp": "せんえん=1000 yen",
-    "example_en": "thousand"
-  },
-  "practice": "Write 千 20 times. Learn: せんえん=1000 yen",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 千 and practice carefully!"
-}, {
-  "day": 265,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 38,
-  "title": "Kanji: 万 (ten thousand)",
-  "intro": "Today's kanji: 万. Readings: man. Meaning: ten thousand.",
-  "type": "kanji",
-  "chars": [["万", "man"]],
-  "vocab": [["万", "man", "ten thousand"], ["いちまんえん", "いちまんえん=10,000 yen", ""]],
-  "grammar": {
-    "pattern": "万 in words",
-    "meaning": "ten thousand",
-    "example_jp": "いちまんえん=10",
-    "example_en": "ten thousand"
-  },
-  "practice": "Write 万 20 times. Learn: いちまんえん=10,000 yen",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 万 and practice carefully!"
-}, {
-  "day": 266,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 38,
-  "title": "Kanji: 円 (yen/circle)",
-  "intro": "Today's kanji: 円. Readings: en/maru. Meaning: yen/circle.",
-  "type": "kanji",
-  "chars": [["円", "en/maru"]],
-  "vocab": [["円", "en/maru", "yen/circle"], ["えん", "えん=yen currency", ""]],
-  "grammar": {
-    "pattern": "円 in words",
-    "meaning": "yen/circle",
-    "example_jp": "えん=yen currency",
-    "example_en": "yen/circle"
-  },
-  "practice": "Write 円 20 times. Learn: えん=yen currency",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 円 and practice carefully!"
-}, {
-  "day": 267,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 39,
-  "title": "Kanji: 年 (year)",
-  "intro": "Today's kanji: 年. Readings: nen/toshi. Meaning: year.",
-  "type": "kanji",
-  "chars": [["年", "nen/toshi"]],
-  "vocab": [["年", "nen/toshi", "year"], ["ことし", "ことし=this year, いちねん=1 year", ""]],
-  "grammar": {
-    "pattern": "年 in words",
-    "meaning": "year",
-    "example_jp": "ことし=this year",
-    "example_en": "year"
-  },
-  "practice": "Write 年 20 times. Learn: ことし=this year, いちねん=1 year",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 年 and practice carefully!"
-}, {
-  "day": 268,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 39,
-  "title": "Kanji: 月 (month/moon)",
-  "intro": "Today's kanji: 月. Readings: tsuki/gatsu. Meaning: month/moon.",
-  "type": "kanji",
-  "chars": [["月", "tsuki/gatsu"]],
-  "vocab": [["月", "tsuki/gatsu", "month/moon"], ["こんげつ", "こんげつ=this month, つき=moon", ""]],
-  "grammar": {
-    "pattern": "月 in words",
-    "meaning": "month/moon",
-    "example_jp": "こんげつ=this month",
-    "example_en": "month/moon"
-  },
-  "practice": "Write 月 20 times. Learn: こんげつ=this month, つき=moon",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 月 and practice carefully!"
-}, {
-  "day": 269,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 39,
-  "title": "Kanji: 日 (day/sun)",
-  "intro": "Today's kanji: 日. Readings: nichi/ka/hi. Meaning: day/sun.",
-  "type": "kanji",
-  "chars": [["日", "nichi/ka/hi"]],
-  "vocab": [["日", "nichi/ka/hi", "day/sun"], ["きょう", "きょう=today, まいにち=every day", ""]],
-  "grammar": {
-    "pattern": "日 in words",
-    "meaning": "day/sun",
-    "example_jp": "きょう=today",
-    "example_en": "day/sun"
-  },
-  "practice": "Write 日 20 times. Learn: きょう=today, まいにち=every day",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 日 and practice carefully!"
-}, {
-  "day": 270,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 39,
-  "title": "Kanji: 時 (time/hour)",
-  "intro": "Today's kanji: 時. Readings: ji/toki. Meaning: time/hour.",
-  "type": "kanji",
-  "chars": [["時", "ji/toki"]],
-  "vocab": [["時", "ji/toki", "time/hour"], ["なんじ", "なんじ=what time, いまのとき=now", ""]],
-  "grammar": {
-    "pattern": "時 in words",
-    "meaning": "time/hour",
-    "example_jp": "なんじ=what time",
-    "example_en": "time/hour"
-  },
-  "practice": "Write 時 20 times. Learn: なんじ=what time, いまのとき=now",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 時 and practice carefully!"
-}, {
-  "day": 271,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 39,
-  "title": "Kanji: 分 (minute/divide)",
-  "intro": "Today's kanji: 分. Readings: fun/pun/wak. Meaning: minute/divide.",
-  "type": "kanji",
-  "chars": [["分", "fun/pun/wak"]],
-  "vocab": [["分", "fun/pun/wak", "minute/divide"], ["ごふん", "ごふん=5 min, わかる=understand", ""]],
-  "grammar": {
-    "pattern": "分 in words",
-    "meaning": "minute/divide",
-    "example_jp": "ごふん=5 min",
-    "example_en": "minute/divide"
-  },
-  "practice": "Write 分 20 times. Learn: ごふん=5 min, わかる=understand",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 分 and practice carefully!"
-}, {
-  "day": 272,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 39,
-  "title": "Kanji: 週 (week)",
-  "intro": "Today's kanji: 週. Readings: shuu. Meaning: week.",
-  "type": "kanji",
-  "chars": [["週", "shuu"]],
-  "vocab": [["週", "shuu", "week"], ["こんしゅう", "こんしゅう=this week", ""]],
-  "grammar": {
-    "pattern": "週 in words",
-    "meaning": "week",
-    "example_jp": "こんしゅう=this week",
-    "example_en": "week"
-  },
-  "practice": "Write 週 20 times. Learn: こんしゅう=this week",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 週 and practice carefully!"
-}, {
-  "day": 273,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 39,
-  "title": "Kanji: 間 (between/space)",
-  "intro": "Today's kanji: 間. Readings: kan/aida. Meaning: between/space.",
-  "type": "kanji",
-  "chars": [["間", "kan/aida"]],
-  "vocab": [["間", "kan/aida", "between/space"], ["じかん", "じかん=time, あいだ=between", ""]],
-  "grammar": {
-    "pattern": "間 in words",
-    "meaning": "between/space",
-    "example_jp": "じかん=time",
-    "example_en": "between/space"
-  },
-  "practice": "Write 間 20 times. Learn: じかん=time, あいだ=between",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 間 and practice carefully!"
-}, {
-  "day": 274,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 40,
-  "title": "Kanji: 今 (now)",
-  "intro": "Today's kanji: 今. Readings: ima/kon. Meaning: now.",
-  "type": "kanji",
-  "chars": [["今", "ima/kon"]],
-  "vocab": [["今", "ima/kon", "now"], ["いま", "いま=now, こんにち=today", ""]],
-  "grammar": {
-    "pattern": "今 in words",
-    "meaning": "now",
-    "example_jp": "いま=now",
-    "example_en": "now"
-  },
-  "practice": "Write 今 20 times. Learn: いま=now, こんにち=today",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 今 and practice carefully!"
-}, {
-  "day": 275,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 40,
-  "title": "Kanji: 本 (book/origin)",
-  "intro": "Today's kanji: 本. Readings: hon/moto. Meaning: book/origin.",
-  "type": "kanji",
-  "chars": [["本", "hon/moto"]],
-  "vocab": [["本", "hon/moto", "book/origin"], ["ほん", "ほん=book, にほん=Japan", ""]],
-  "grammar": {
-    "pattern": "本 in words",
-    "meaning": "book/origin",
-    "example_jp": "ほん=book",
-    "example_en": "book/origin"
-  },
-  "practice": "Write 本 20 times. Learn: ほん=book, にほん=Japan",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 本 and practice carefully!"
-}, {
-  "day": 276,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 40,
-  "title": "Kanji: 語 (language)",
-  "intro": "Today's kanji: 語. Readings: go. Meaning: language.",
-  "type": "kanji",
-  "chars": [["語", "go"]],
-  "vocab": [["語", "go", "language"], ["にほんご", "にほんご=Japanese", ""]],
-  "grammar": {
-    "pattern": "語 in words",
-    "meaning": "language",
-    "example_jp": "にほんご=Japanese",
-    "example_en": "language"
-  },
-  "practice": "Write 語 20 times. Learn: にほんご=Japanese",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 語 and practice carefully!"
-}, {
-  "day": 277,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 40,
-  "title": "Kanji: 字 (character/letter)",
-  "intro": "Today's kanji: 字. Readings: ji. Meaning: character/letter.",
-  "type": "kanji",
-  "chars": [["字", "ji"]],
-  "vocab": [["字", "ji", "character/letter"], ["もじ", "もじ=written character, かんじ=kanji", ""]],
-  "grammar": {
-    "pattern": "字 in words",
-    "meaning": "character/letter",
-    "example_jp": "もじ=written character",
-    "example_en": "character/letter"
-  },
-  "practice": "Write 字 20 times. Learn: もじ=written character, かんじ=kanji",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 字 and practice carefully!"
-}, {
-  "day": 278,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 40,
-  "title": "Kanji: 学 (study)",
-  "intro": "Today's kanji: 学. Readings: gaku/mana. Meaning: study.",
-  "type": "kanji",
-  "chars": [["学", "gaku/mana"]],
-  "vocab": [["学", "gaku/mana", "study"], ["だいがく", "だいがく=university, がくせい=student", ""]],
-  "grammar": {
-    "pattern": "学 in words",
-    "meaning": "study",
-    "example_jp": "だいがく=university",
-    "example_en": "study"
-  },
-  "practice": "Write 学 20 times. Learn: だいがく=university, がくせい=student",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 学 and practice carefully!"
-}, {
-  "day": 279,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 40,
-  "title": "Kanji: 校 (school)",
-  "intro": "Today's kanji: 校. Readings: kou. Meaning: school.",
-  "type": "kanji",
-  "chars": [["校", "kou"]],
-  "vocab": [["校", "kou", "school"], ["がっこう", "がっこう=school, こうちょう=principal", ""]],
-  "grammar": {
-    "pattern": "校 in words",
-    "meaning": "school",
-    "example_jp": "がっこう=school",
-    "example_en": "school"
-  },
-  "practice": "Write 校 20 times. Learn: がっこう=school, こうちょう=principal",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 校 and practice carefully!"
-}, {
-  "day": 280,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 40,
-  "title": "Kanji: 先 (before/ahead)",
-  "intro": "Today's kanji: 先. Readings: sen/saki. Meaning: before/ahead.",
-  "type": "kanji",
-  "chars": [["先", "sen/saki"]],
-  "vocab": [["先", "sen/saki", "before/ahead"], ["せんせい", "せんせい=teacher, さき=ahead", ""]],
-  "grammar": {
-    "pattern": "先 in words",
-    "meaning": "before/ahead",
-    "example_jp": "せんせい=teacher",
-    "example_en": "before/ahead"
-  },
-  "practice": "Write 先 20 times. Learn: せんせい=teacher, さき=ahead",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 先 and practice carefully!"
-}, {
-  "day": 281,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 41,
-  "title": "Kanji: 生 (life/birth)",
-  "intro": "Today's kanji: 生. Readings: sei/i/u. Meaning: life/birth.",
-  "type": "kanji",
-  "chars": [["生", "sei/i/u"]],
-  "vocab": [["生", "sei/i/u", "life/birth"], ["がくせい", "がくせい=student, うまれる=be born", ""]],
-  "grammar": {
-    "pattern": "生 in words",
-    "meaning": "life/birth",
-    "example_jp": "がくせい=student",
-    "example_en": "life/birth"
-  },
-  "practice": "Write 生 20 times. Learn: がくせい=student, うまれる=be born",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 生 and practice carefully!"
-}, {
-  "day": 282,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 41,
-  "title": "Kanji: 友 (friend)",
-  "intro": "Today's kanji: 友. Readings: yuu/tomo. Meaning: friend.",
-  "type": "kanji",
-  "chars": [["友", "yuu/tomo"]],
-  "vocab": [["友", "yuu/tomo", "friend"], ["ともだち", "ともだち=friend, ゆうじん=friend (formal)", ""]],
-  "grammar": {
-    "pattern": "友 in words",
-    "meaning": "friend",
-    "example_jp": "ともだち=friend",
-    "example_en": "friend"
-  },
-  "practice": "Write 友 20 times. Learn: ともだち=friend, ゆうじん=friend (formal)",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 友 and practice carefully!"
-}, {
-  "day": 283,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 41,
-  "title": "Kanji: 人 (person)",
-  "intro": "Today's kanji: 人. Readings: jin/hito. Meaning: person.",
-  "type": "kanji",
-  "chars": [["人", "jin/hito"]],
-  "vocab": [["人", "jin/hito", "person"], ["にほんじん", "にほんじん=Japanese, ひと=person", ""]],
-  "grammar": {
-    "pattern": "人 in words",
-    "meaning": "person",
-    "example_jp": "にほんじん=Japanese",
-    "example_en": "person"
-  },
-  "practice": "Write 人 20 times. Learn: にほんじん=Japanese, ひと=person",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 人 and practice carefully!"
-}, {
-  "day": 284,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 41,
-  "title": "Kanji: 名 (name)",
-  "intro": "Today's kanji: 名. Readings: mei/na. Meaning: name.",
-  "type": "kanji",
-  "chars": [["名", "mei/na"]],
-  "vocab": [["名", "mei/na", "name"], ["なまえ", "なまえ=name, めいし=business card", ""]],
-  "grammar": {
-    "pattern": "名 in words",
-    "meaning": "name",
-    "example_jp": "なまえ=name",
-    "example_en": "name"
-  },
-  "practice": "Write 名 20 times. Learn: なまえ=name, めいし=business card",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 名 and practice carefully!"
-}, {
-  "day": 285,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 41,
-  "title": "Kanji: 電 (electricity)",
-  "intro": "Today's kanji: 電. Readings: den. Meaning: electricity.",
-  "type": "kanji",
-  "chars": [["電", "den"]],
-  "vocab": [["電", "den", "electricity"], ["でんしゃ", "でんしゃ=train, でんわ=phone, でんき=electricity", ""]],
-  "grammar": {
-    "pattern": "電 in words",
-    "meaning": "electricity",
-    "example_jp": "でんしゃ=train",
-    "example_en": "electricity"
-  },
-  "practice": "Write 電 20 times. Learn: でんしゃ=train, でんわ=phone, でんき=electricity",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 電 and practice carefully!"
-}, {
-  "day": 286,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 41,
-  "title": "Kanji: 話 (speech/talk)",
-  "intro": "Today's kanji: 話. Readings: wa/hana. Meaning: speech/talk.",
-  "type": "kanji",
-  "chars": [["話", "wa/hana"]],
-  "vocab": [["話", "wa/hana", "speech/talk"], ["でんわ", "でんわ=phone, はなす=speak", ""]],
-  "grammar": {
-    "pattern": "話 in words",
-    "meaning": "speech/talk",
-    "example_jp": "でんわ=phone",
-    "example_en": "speech/talk"
-  },
-  "practice": "Write 話 20 times. Learn: でんわ=phone, はなす=speak",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 話 and practice carefully!"
-}, {
-  "day": 287,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 41,
-  "title": "Kanji: 何 (what)",
-  "intro": "Today's kanji: 何. Readings: nani/nan. Meaning: what.",
-  "type": "kanji",
-  "chars": [["何", "nani/nan"]],
-  "vocab": [["何", "nani/nan", "what"], ["なに", "なに=what, なんじ=what time", ""]],
-  "grammar": {
-    "pattern": "何 in words",
-    "meaning": "what",
-    "example_jp": "なに=what",
-    "example_en": "what"
-  },
-  "practice": "Write 何 20 times. Learn: なに=what, なんじ=what time",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 何 and practice carefully!"
-}, {
-  "day": 288,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 42,
-  "title": "Kanji: 大 (big)",
-  "intro": "Today's kanji: 大. Readings: dai/oo. Meaning: big.",
-  "type": "kanji",
-  "chars": [["大", "dai/oo"]],
-  "vocab": [["大", "dai/oo", "big"], ["おおきい", "おおきい=big, だいがく=university", ""]],
-  "grammar": {
-    "pattern": "大 in words",
-    "meaning": "big",
-    "example_jp": "おおきい=big",
-    "example_en": "big"
-  },
-  "practice": "Write 大 20 times. Learn: おおきい=big, だいがく=university",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 大 and practice carefully!"
-}, {
-  "day": 289,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 42,
-  "title": "Kanji: 小 (small)",
-  "intro": "Today's kanji: 小. Readings: shou/chii. Meaning: small.",
-  "type": "kanji",
-  "chars": [["小", "shou/chii"]],
-  "vocab": [["小", "shou/chii", "small"], ["ちいさい", "ちいさい=small, しょうがっこう=elementary school", ""]],
-  "grammar": {
-    "pattern": "小 in words",
-    "meaning": "small",
-    "example_jp": "ちいさい=small",
-    "example_en": "small"
-  },
-  "practice": "Write 小 20 times. Learn: ちいさい=small, しょうがっこう=elementary school",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 小 and practice carefully!"
-}, {
-  "day": 290,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 42,
-  "title": "Kanji: 山 (mountain)",
-  "intro": "Today's kanji: 山. Readings: san/yama. Meaning: mountain.",
-  "type": "kanji",
-  "chars": [["山", "san/yama"]],
-  "vocab": [["山", "san/yama", "mountain"], ["やま", "やま=mountain, ふじさん=Mt Fuji", ""]],
-  "grammar": {
-    "pattern": "山 in words",
-    "meaning": "mountain",
-    "example_jp": "やま=mountain",
-    "example_en": "mountain"
-  },
-  "practice": "Write 山 20 times. Learn: やま=mountain, ふじさん=Mt Fuji",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 山 and practice carefully!"
-}, {
-  "day": 291,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 42,
-  "title": "Kanji: 川 (river)",
-  "intro": "Today's kanji: 川. Readings: sen/kawa. Meaning: river.",
-  "type": "kanji",
-  "chars": [["川", "sen/kawa"]],
-  "vocab": [["川", "sen/kawa", "river"], ["かわ", "かわ=river, もがわ=various rivers", ""]],
-  "grammar": {
-    "pattern": "川 in words",
-    "meaning": "river",
-    "example_jp": "かわ=river",
-    "example_en": "river"
-  },
-  "practice": "Write 川 20 times. Learn: かわ=river, もがわ=various rivers",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 川 and practice carefully!"
-}, {
-  "day": 292,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 42,
-  "title": "Kanji: 空 (sky/empty)",
-  "intro": "Today's kanji: 空. Readings: kuu/sora/a. Meaning: sky/empty.",
-  "type": "kanji",
-  "chars": [["空", "kuu/sora/a"]],
-  "vocab": [["空", "kuu/sora/a", "sky/empty"], ["そら", "そら=sky, くうこう=airport", ""]],
-  "grammar": {
-    "pattern": "空 in words",
-    "meaning": "sky/empty",
-    "example_jp": "そら=sky",
-    "example_en": "sky/empty"
-  },
-  "practice": "Write 空 20 times. Learn: そら=sky, くうこう=airport",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 空 and practice carefully!"
-}, {
-  "day": 293,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 42,
-  "title": "Kanji: 海 (sea)",
-  "intro": "Today's kanji: 海. Readings: kai/umi. Meaning: sea.",
-  "type": "kanji",
-  "chars": [["海", "kai/umi"]],
-  "vocab": [["海", "kai/umi", "sea"], ["うみ", "うみ=sea, かいすいよく=sea bathing", ""]],
-  "grammar": {
-    "pattern": "海 in words",
-    "meaning": "sea",
-    "example_jp": "うみ=sea",
-    "example_en": "sea"
-  },
-  "practice": "Write 海 20 times. Learn: うみ=sea, かいすいよく=sea bathing",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 海 and practice carefully!"
-}, {
-  "day": 294,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 42,
-  "title": "Kanji: 土 (earth/soil)",
-  "intro": "Today's kanji: 土. Readings: do/tsuchi. Meaning: earth/soil.",
-  "type": "kanji",
-  "chars": [["土", "do/tsuchi"]],
-  "vocab": [["土", "do/tsuchi", "earth/soil"], ["どようび", "どようび=Saturday, つち=soil", ""]],
-  "grammar": {
-    "pattern": "土 in words",
-    "meaning": "earth/soil",
-    "example_jp": "どようび=Saturday",
-    "example_en": "earth/soil"
-  },
-  "practice": "Write 土 20 times. Learn: どようび=Saturday, つち=soil",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 土 and practice carefully!"
-}, {
-  "day": 295,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 43,
-  "title": "Kanji: 木 (tree/wood)",
-  "intro": "Today's kanji: 木. Readings: moku/ki. Meaning: tree/wood.",
-  "type": "kanji",
-  "chars": [["木", "moku/ki"]],
-  "vocab": [["木", "moku/ki", "tree/wood"], ["き", "き=tree, もくようび=Thursday", ""]],
-  "grammar": {
-    "pattern": "木 in words",
-    "meaning": "tree/wood",
-    "example_jp": "き=tree",
-    "example_en": "tree/wood"
-  },
-  "practice": "Write 木 20 times. Learn: き=tree, もくようび=Thursday",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 木 and practice carefully!"
-}, {
-  "day": 296,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 43,
-  "title": "Kanji: 火 (fire)",
-  "intro": "Today's kanji: 火. Readings: ka/hi. Meaning: fire.",
-  "type": "kanji",
-  "chars": [["火", "ka/hi"]],
-  "vocab": [["火", "ka/hi", "fire"], ["ひ", "ひ=fire, かようび=Tuesday", ""]],
-  "grammar": {
-    "pattern": "火 in words",
-    "meaning": "fire",
-    "example_jp": "ひ=fire",
-    "example_en": "fire"
-  },
-  "practice": "Write 火 20 times. Learn: ひ=fire, かようび=Tuesday",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 火 and practice carefully!"
-}, {
-  "day": 297,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 43,
-  "title": "Kanji: 水 (water)",
-  "intro": "Today's kanji: 水. Readings: sui/mizu. Meaning: water.",
-  "type": "kanji",
-  "chars": [["水", "sui/mizu"]],
-  "vocab": [["水", "sui/mizu", "water"], ["みず", "みず=water, すいようび=Wednesday", ""]],
-  "grammar": {
-    "pattern": "水 in words",
-    "meaning": "water",
-    "example_jp": "みず=water",
-    "example_en": "water"
-  },
-  "practice": "Write 水 20 times. Learn: みず=water, すいようび=Wednesday",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 水 and practice carefully!"
-}, {
-  "day": 298,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 43,
-  "title": "Kanji: 金 (gold/money)",
-  "intro": "Today's kanji: 金. Readings: kin/kana. Meaning: gold/money.",
-  "type": "kanji",
-  "chars": [["金", "kin/kana"]],
-  "vocab": [["金", "kin/kana", "gold/money"], ["おかね", "おかね=money, きんようび=Friday", ""]],
-  "grammar": {
-    "pattern": "金 in words",
-    "meaning": "gold/money",
-    "example_jp": "おかね=money",
-    "example_en": "gold/money"
-  },
-  "practice": "Write 金 20 times. Learn: おかね=money, きんようび=Friday",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 金 and practice carefully!"
-}, {
-  "day": 299,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 43,
-  "title": "Kanji: 女 (woman)",
-  "intro": "Today's kanji: 女. Readings: jo/onna. Meaning: woman.",
-  "type": "kanji",
-  "chars": [["女", "jo/onna"]],
-  "vocab": [["女", "jo/onna", "woman"], ["おんなのひと", "おんなのひと=woman, じょせい=female", ""]],
-  "grammar": {
-    "pattern": "女 in words",
-    "meaning": "woman",
-    "example_jp": "おんなのひと=woman",
-    "example_en": "woman"
-  },
-  "practice": "Write 女 20 times. Learn: おんなのひと=woman, じょせい=female",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 女 and practice carefully!"
-}, {
-  "day": 300,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 43,
-  "title": "Kanji: 男 (man)",
-  "intro": "Today's kanji: 男. Readings: dan/otoko. Meaning: man.",
-  "type": "kanji",
-  "chars": [["男", "dan/otoko"]],
-  "vocab": [["男", "dan/otoko", "man"], ["おとこのひと", "おとこのひと=man, だんせい=male", ""]],
-  "grammar": {
-    "pattern": "男 in words",
-    "meaning": "man",
-    "example_jp": "おとこのひと=man",
-    "example_en": "man"
-  },
-  "practice": "Write 男 20 times. Learn: おとこのひと=man, だんせい=male",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 男 and practice carefully!"
-}, {
-  "day": 301,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 43,
-  "title": "Kanji: 車 (car)",
-  "intro": "Today's kanji: 車. Readings: sha/kuruma. Meaning: car.",
-  "type": "kanji",
-  "chars": [["車", "sha/kuruma"]],
-  "vocab": [["車", "sha/kuruma", "car"], ["くるま", "くるま=car, でんしゃ=train", ""]],
-  "grammar": {
-    "pattern": "車 in words",
-    "meaning": "car",
-    "example_jp": "くるま=car",
-    "example_en": "car"
-  },
-  "practice": "Write 車 20 times. Learn: くるま=car, でんしゃ=train",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 車 and practice carefully!"
-}, {
-  "day": 302,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 44,
-  "title": "Kanji: 道 (road/way)",
-  "intro": "Today's kanji: 道. Readings: dou/michi. Meaning: road/way.",
-  "type": "kanji",
-  "chars": [["道", "dou/michi"]],
-  "vocab": [["道", "dou/michi", "road/way"], ["みち", "みち=road, どうろ=road/street", ""]],
-  "grammar": {
-    "pattern": "道 in words",
-    "meaning": "road/way",
-    "example_jp": "みち=road",
-    "example_en": "road/way"
-  },
-  "practice": "Write 道 20 times. Learn: みち=road, どうろ=road/street",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 道 and practice carefully!"
-}, {
-  "day": 303,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 44,
-  "title": "Kanji: 国 (country)",
-  "intro": "Today's kanji: 国. Readings: koku/kuni. Meaning: country.",
-  "type": "kanji",
-  "chars": [["国", "koku/kuni"]],
-  "vocab": [["国", "koku/kuni", "country"], ["くに", "くに=country, にほんこく=Japan", ""]],
-  "grammar": {
-    "pattern": "国 in words",
-    "meaning": "country",
-    "example_jp": "くに=country",
-    "example_en": "country"
-  },
-  "practice": "Write 国 20 times. Learn: くに=country, にほんこく=Japan",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 国 and practice carefully!"
-}, {
-  "day": 304,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 44,
-  "title": "Kanji: 外 (outside/foreign)",
-  "intro": "Today's kanji: 外. Readings: gai/soto. Meaning: outside/foreign.",
-  "type": "kanji",
-  "chars": [["外", "gai/soto"]],
-  "vocab": [["外", "gai/soto", "outside/foreign"], ["そと", "そと=outside, がいこく=foreign country", ""]],
-  "grammar": {
-    "pattern": "外 in words",
-    "meaning": "outside/foreign",
-    "example_jp": "そと=outside",
-    "example_en": "outside/foreign"
-  },
-  "practice": "Write 外 20 times. Learn: そと=outside, がいこく=foreign country",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 外 and practice carefully!"
-}, {
-  "day": 305,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 44,
-  "title": "Kanji: 上 (above/up)",
-  "intro": "Today's kanji: 上. Readings: jou/ue. Meaning: above/up.",
-  "type": "kanji",
-  "chars": [["上", "jou/ue"]],
-  "vocab": [["上", "jou/ue", "above/up"], ["うえ", "うえ=above, うえに=on top of", ""]],
-  "grammar": {
-    "pattern": "上 in words",
-    "meaning": "above/up",
-    "example_jp": "うえ=above",
-    "example_en": "above/up"
-  },
-  "practice": "Write 上 20 times. Learn: うえ=above, うえに=on top of",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 上 and practice carefully!"
-}, {
-  "day": 306,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 44,
-  "title": "Kanji: 下 (below/down)",
-  "intro": "Today's kanji: 下. Readings: ka/shita. Meaning: below/down.",
-  "type": "kanji",
-  "chars": [["下", "ka/shita"]],
-  "vocab": [["下", "ka/shita", "below/down"], ["した", "した=below, ちか=underground", ""]],
-  "grammar": {
-    "pattern": "下 in words",
-    "meaning": "below/down",
-    "example_jp": "した=below",
-    "example_en": "below/down"
-  },
-  "practice": "Write 下 20 times. Learn: した=below, ちか=underground",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 下 and practice carefully!"
-}, {
-  "day": 307,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 44,
-  "title": "Kanji: 右 (right)",
-  "intro": "Today's kanji: 右. Readings: u/migi. Meaning: right.",
-  "type": "kanji",
-  "chars": [["右", "u/migi"]],
-  "vocab": [["右", "u/migi", "right"], ["みぎ", "みぎ=right, みぎて=right hand", ""]],
-  "grammar": {
-    "pattern": "右 in words",
-    "meaning": "right",
-    "example_jp": "みぎ=right",
-    "example_en": "right"
-  },
-  "practice": "Write 右 20 times. Learn: みぎ=right, みぎて=right hand",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 右 and practice carefully!"
-}, {
-  "day": 308,
-  "phaseNum": 7,
-  "phaseName": "Kanji",
-  "week": 44,
-  "title": "Kanji: 左 (left)",
-  "intro": "Today's kanji: 左. Readings: sa/hidari. Meaning: left.",
-  "type": "kanji",
-  "chars": [["左", "sa/hidari"]],
-  "vocab": [["左", "sa/hidari", "left"], ["ひだり", "ひだり=left, ひだりて=left hand", ""]],
-  "grammar": {
-    "pattern": "左 in words",
-    "meaning": "left",
-    "example_jp": "ひだり=left",
-    "example_en": "left"
-  },
-  "practice": "Write 左 20 times. Learn: ひだり=left, ひだりて=left hand",
-  "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 左 and practice carefully!"
-}, {
-  "day": 309,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 45,
-  "title": "Hiragana & Katakana Speed Reading",
-  "intro": "Speed is key on the JLPT! Practice reading kana as fast as possible today.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 310,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 45,
-  "title": "Kanji Recognition Review (一〜百)",
-  "intro": "Test yourself on the number and time kanji. These appear frequently on N5.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 311,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 45,
-  "title": "Kanji Recognition Review (年〜電)",
-  "intro": "Today's focus: Kanji Recognition Review (年〜電). Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 312,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 45,
-  "title": "Kanji Recognition Review (何〜左)",
-  "intro": "Today's focus: Kanji Recognition Review (何〜左). Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 313,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 45,
-  "title": "Full Kanji Writing Test",
-  "intro": "Today's focus: Full Kanji Writing Test. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 314,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 45,
-  "title": "Vocabulary Review: People & Family",
-  "intro": "Today's focus: Vocabulary Review: People & Family. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 315,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 45,
-  "title": "Vocabulary Review: Places & Transport",
-  "intro": "Today's focus: Vocabulary Review: Places & Transport. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 316,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 46,
-  "title": "Vocabulary Review: Food & Daily Life",
-  "intro": "Today's focus: Vocabulary Review: Food & Daily Life. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 317,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 46,
-  "title": "Vocabulary Review: Nature & Weather",
-  "intro": "Today's focus: Vocabulary Review: Nature & Weather. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 318,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 46,
-  "title": "Vocabulary Review: Verbs (Actions)",
-  "intro": "Verbs are the heart of Japanese sentences. Review all action verbs learned in Phase 5.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 319,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 46,
-  "title": "Vocabulary Review: Adjectives",
-  "intro": "Today's focus: Vocabulary Review: Adjectives. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 320,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 46,
-  "title": "JLPT N5 Vocabulary Practice Test 1",
-  "intro": "Simulate exam conditions: timer on, no notes, choose the best answer.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 321,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 46,
-  "title": "JLPT N5 Vocabulary Practice Test 2",
-  "intro": "Today's focus: JLPT N5 Vocabulary Practice Test 2. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 322,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 46,
-  "title": "Particle Review: は・が・を・の",
-  "intro": "Today's focus: Particle Review: は・が・を・の. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 323,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 47,
-  "title": "Particle Review: に・で・と・から・まで",
-  "intro": "Today's focus: Particle Review: に・で・と・から・まで. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 324,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 47,
-  "title": "Grammar Review: て-form Uses",
-  "intro": "The て-form has so many uses! Review them all: request, sequence, progressive, permission.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 325,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 47,
-  "title": "Grammar Review: Verb Conjugation",
-  "intro": "Today's focus: Grammar Review: Verb Conjugation. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 326,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 47,
-  "title": "Grammar Review: Adjective Forms",
-  "intro": "Today's focus: Grammar Review: Adjective Forms. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 327,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 47,
-  "title": "Grammar Review: Permission & Obligation",
-  "intro": "Today's focus: Grammar Review: Permission & Obligation. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 328,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 47,
-  "title": "Grammar Review: Conditionals",
-  "intro": "Today's focus: Grammar Review: Conditionals. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 329,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 47,
-  "title": "JLPT N5 Grammar Practice Test 1",
-  "intro": "Timed practice. Try to answer each question in 30 seconds or less.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 330,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 48,
-  "title": "JLPT N5 Grammar Practice Test 2",
-  "intro": "Today's focus: JLPT N5 Grammar Practice Test 2. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 331,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 48,
-  "title": "Reading Practice: Short Passages (Daily Life)",
-  "intro": "N5 reading uses short, simple passages. Focus on scanning for key information.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 332,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 48,
-  "title": "Reading Practice: Emails & Messages",
-  "intro": "Today's focus: Reading Practice: Emails & Messages. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 333,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 48,
-  "title": "Reading Practice: Signs & Notices",
-  "intro": "Today's focus: Reading Practice: Signs & Notices. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 334,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 48,
-  "title": "Reading Practice: Short Stories",
-  "intro": "Today's focus: Reading Practice: Short Stories. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 335,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 48,
-  "title": "JLPT N5 Reading Practice Test",
-  "intro": "Today's focus: JLPT N5 Reading Practice Test. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 336,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 48,
-  "title": "Listening Strategy: Key Words",
-  "intro": "In JLPT listening, focus on key words (time, place, person, action) rather than understanding everything.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 337,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 49,
-  "title": "Listening Strategy: Numbers & Times",
-  "intro": "Today's focus: Listening Strategy: Numbers & Times. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 338,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 49,
-  "title": "Listening Strategy: Directions",
-  "intro": "Today's focus: Listening Strategy: Directions. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 339,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 49,
-  "title": "Listening Practice: Dialogues",
-  "intro": "Today's focus: Listening Practice: Dialogues. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 340,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 49,
-  "title": "JLPT N5 Listening Practice (Scripts)",
-  "intro": "Today's focus: JLPT N5 Listening Practice (Scripts). Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 341,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 49,
-  "title": "Mock Test 1: Vocabulary Section",
-  "intro": "Full simulation! Vocabulary section: 25 questions, 25 minutes.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 342,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 49,
-  "title": "Mock Test 1: Grammar Section",
-  "intro": "Today's focus: Mock Test 1: Grammar Section. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 343,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 49,
-  "title": "Mock Test 1: Reading Section",
-  "intro": "Today's focus: Mock Test 1: Reading Section. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 344,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 50,
-  "title": "Mock Test 1: Review & Analysis",
-  "intro": "Today's focus: Mock Test 1: Review & Analysis. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 345,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 50,
-  "title": "Weak Area Study: Vocabulary",
-  "intro": "Today's focus: Weak Area Study: Vocabulary. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 346,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 50,
-  "title": "Weak Area Study: Grammar",
-  "intro": "Today's focus: Weak Area Study: Grammar. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 347,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 50,
-  "title": "Weak Area Study: Kanji",
-  "intro": "Today's focus: Weak Area Study: Kanji. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 348,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 50,
-  "title": "Full Mock Test 2",
-  "intro": "Full N5 mock exam under exam conditions. 90 minutes total.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 349,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 50,
-  "title": "Mock Test 2: Review & Analysis",
-  "intro": "Today's focus: Mock Test 2: Review & Analysis. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 350,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 50,
-  "title": "JLPT Test-Taking Strategies",
-  "intro": "Today's focus: JLPT Test-Taking Strategies. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 351,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 51,
-  "title": "Time Management Practice",
-  "intro": "Today's focus: Time Management Practice. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 352,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 51,
-  "title": "Final Vocabulary Review",
-  "intro": "Today's focus: Final Vocabulary Review. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 353,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 51,
-  "title": "Final Grammar Review",
-  "intro": "Today's focus: Final Grammar Review. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 354,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 51,
-  "title": "Final Kanji Review",
-  "intro": "Today's focus: Final Kanji Review. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 355,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 51,
-  "title": "Confidence Building: What You Know",
-  "intro": "Today's focus: Confidence Building: What You Know. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 356,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 51,
-  "title": "Light Reading Practice",
-  "intro": "Today's focus: Light Reading Practice. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 357,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 51,
-  "title": "Final Mock Exam",
-  "intro": "Today's focus: Final Mock Exam. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 358,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 52,
-  "title": "Final Mock Exam: Review",
-  "intro": "Today's focus: Final Mock Exam: Review. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 359,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 52,
-  "title": "Rest & Light Review",
-  "intro": "Today's focus: Rest & Light Review. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 360,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 52,
-  "title": "Final Preparations",
-  "intro": "Today's focus: Final Preparations. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 361,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 52,
-  "title": "Relax & Prepare",
-  "intro": "Today's focus: Relax & Prepare. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 362,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 52,
-  "title": "Day Before Exam: Rest!",
-  "intro": "Today's focus: Day Before Exam: Rest!. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 363,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 52,
-  "title": "Day 365: Course Complete! 🎉",
-  "intro": "CONGRATULATIONS! You've completed 365 days of Japanese study! You're ready for JLPT N5!",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 364,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 52,
-  "title": "Day 365 Plus: What's Next (N4 Preview)",
-  "intro": "Today's focus: Day 365 Plus: What's Next (N4 Preview). Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
-  "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
-}, {
-  "day": 365,
-  "phaseNum": 8,
-  "phaseName": "Test Prep",
-  "week": 53,
-  "title": "Day 366: Bonus — Japanese Culture Tips",
-  "intro": "Today's focus: Day 366: Bonus — Japanese Culture Tips. Review, practice, and consolidate what you've learned.",
-  "type": "review",
-  "chars": [],
-  "vocab": [["れんしゅう", "れんしゅう", "practice"], ["かくにん", "かくにん", "confirmation/review"], ["もくひょう", "もくひょう", "goal"], ["しんちょく", "しんちょく", "progress"], ["じしん", "じしん", "confidence"]],
-  "grammar": {
-    "pattern": "Review & Practice",
-    "meaning": "N5 preparation",
-    "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
-    "example_en": "Study a little every day and build your ability"
-  },
-  "practice": "Celebrate your achievement! Write about everything you can now do in Japanese.",
-  "tip": "365 days completed! Celebrate this incredible achievement. Your N5 journey ends here — but your Japanese journey continues forever! Consider JLPT N4 next!"
-}];
-var PHASE_COLORS = {
-  "1": "#e74c3c",
-  "2": "#e67e22",
-  "3": "#f39c12",
-  "4": "#27ae60",
-  "5": "#2980b9",
-  "6": "#8e44ad",
-  "7": "#16a085",
-  "8": "#c0392b"
-};
-var PHASE_BG = {
-  "1": "#fdecea",
-  "2": "#fef3e7",
-  "3": "#fefbea",
-  "4": "#eafaf1",
-  "5": "#eaf4fb",
-  "6": "#f5eef8",
-  "7": "#eafaf1",
-  "8": "#fdecea"
-};
-var PHASE_NAMES = {
-  1: "Hiragana",
-  2: "Katakana",
-  3: "Foundations",
-  4: "Vocabulary",
-  5: "Verbs",
-  6: "Grammar",
-  7: "Kanji",
-  8: "Test Prep"
-};
+var curriculum = [
+  {
+    "day": 1,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: あ行 — The 5 Vowels",
+    "intro": "Welcome to Day 1! The 5 vowels are the backbone of every Japanese sound.",
+    "type": "script",
+    "chars": [
+      [
+        "あ",
+        "a"
+      ],
+      [
+        "い",
+        "i"
+      ],
+      [
+        "う",
+        "u"
+      ],
+      [
+        "え",
+        "e"
+      ],
+      [
+        "お",
+        "o"
+      ]
+    ],
+    "vocab": [
+      [
+        "いえ",
+        "いえ",
+        "house"
+      ],
+      [
+        "あお",
+        "あお",
+        "blue"
+      ],
+      [
+        "うえ",
+        "うえ",
+        "above / up"
+      ],
+      [
+        "あい",
+        "あい",
+        "love / indigo"
+      ],
+      [
+        "おい",
+        "おい",
+        "hey! / nephew"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each vowel 10 times: あ い う え お. Then try reading: いえ (house)  あお (blue)  うえ (above).",
+    "tip": "Vowels: a=ah, i=ee, u=oo, e=eh, o=oh — always pronounced the same!"
+  },
+  {
+    "day": 2,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: か行 — The K-Series",
+    "intro": "Today we learn the か行 (ka-series). These combine the k-sound with each vowel.",
+    "type": "script",
+    "chars": [
+      [
+        "か",
+        "ka"
+      ],
+      [
+        "き",
+        "ki"
+      ],
+      [
+        "く",
+        "ku"
+      ],
+      [
+        "け",
+        "ke"
+      ],
+      [
+        "こ",
+        "ko"
+      ]
+    ],
+    "vocab": [
+      [
+        "かい",
+        "かい",
+        "shell / floor (counter)"
+      ],
+      [
+        "いく",
+        "いく",
+        "to go"
+      ],
+      [
+        "こえ",
+        "こえ",
+        "voice"
+      ],
+      [
+        "おか",
+        "おか",
+        "hill"
+      ],
+      [
+        "きく",
+        "きく",
+        "to listen / chrysanthemum"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each か行 char 8 times. Read aloud: かい いく こえ. Every word only uses letters you know!",
+    "tip": "The k-sound is crisp: ka, ki, ku, ke, ko. Each vowel changes the sound!"
+  },
+  {
+    "day": 3,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: さ行 — The S-Series",
+    "intro": "Time for the さ行 (sa-series). Notice that し and す have unique pronunciations.",
+    "type": "script",
+    "chars": [
+      [
+        "さ",
+        "sa"
+      ],
+      [
+        "し",
+        "shi"
+      ],
+      [
+        "す",
+        "su"
+      ],
+      [
+        "せ",
+        "se"
+      ],
+      [
+        "そ",
+        "so"
+      ]
+    ],
+    "vocab": [
+      [
+        "すし",
+        "すし",
+        "sushi"
+      ],
+      [
+        "かさ",
+        "かさ",
+        "umbrella"
+      ],
+      [
+        "あさ",
+        "あさ",
+        "morning"
+      ],
+      [
+        "さけ",
+        "さけ",
+        "sake / salmon"
+      ],
+      [
+        "しか",
+        "しか",
+        "deer"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: すし かさ あさ. Notice すし uses two of today's characters plus ones you already know!",
+    "tip": "Remember: し=she, す=soo. These are exceptions to the regular pattern!"
+  },
+  {
+    "day": 4,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: た行 — The T-Series",
+    "intro": "Meet the た行 (ta-series). Like し, つ has a special pronunciation.",
+    "type": "script",
+    "chars": [
+      [
+        "た",
+        "ta"
+      ],
+      [
+        "ち",
+        "chi"
+      ],
+      [
+        "つ",
+        "tsu"
+      ],
+      [
+        "て",
+        "te"
+      ],
+      [
+        "と",
+        "to"
+      ]
+    ],
+    "vocab": [
+      [
+        "うた",
+        "うた",
+        "song"
+      ],
+      [
+        "した",
+        "した",
+        "below / under"
+      ],
+      [
+        "てつ",
+        "てつ",
+        "iron / railway"
+      ],
+      [
+        "かた",
+        "かた",
+        "shoulder / person"
+      ],
+      [
+        "すてき",
+        "すてき",
+        "wonderful"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read aloud: うた した すてき. Try writing 'song' (うた) and 'below' (した) from memory.",
+    "tip": "Tricky sounds: ち=chee, つ=tsoo. These take practice to write cleanly!"
+  },
+  {
+    "day": 5,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: な行 — The N-Series",
+    "intro": "The な行 (na-series) is straightforward—each character follows the pattern na, ni, nu, ne, no.",
+    "type": "script",
+    "chars": [
+      [
+        "な",
+        "na"
+      ],
+      [
+        "に",
+        "ni"
+      ],
+      [
+        "ぬ",
+        "nu"
+      ],
+      [
+        "ね",
+        "ne"
+      ],
+      [
+        "の",
+        "no"
+      ]
+    ],
+    "vocab": [
+      [
+        "ねこ",
+        "ねこ",
+        "cat"
+      ],
+      [
+        "ぬの",
+        "ぬの",
+        "cloth / fabric"
+      ],
+      [
+        "なに",
+        "なに",
+        "what?"
+      ],
+      [
+        "いね",
+        "いね",
+        "rice plant"
+      ],
+      [
+        "かな",
+        "かな",
+        "kana (Japanese script)"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: ねこ なに かな. Can you write 'cat' (ねこ) and 'what' (なに) from memory?",
+    "tip": "Simple and consistent: na, ni, nu, ne, no. A great series to build confidence!"
+  },
+  {
+    "day": 6,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: は行 — The H-Series",
+    "intro": "The は行 (ha-series) introduces us to the h-sound. Note: は by itself means 'is' in grammar.",
+    "type": "script",
+    "chars": [
+      [
+        "は",
+        "ha"
+      ],
+      [
+        "ひ",
+        "hi"
+      ],
+      [
+        "ふ",
+        "fu"
+      ],
+      [
+        "へ",
+        "he"
+      ],
+      [
+        "ほ",
+        "ho"
+      ]
+    ],
+    "vocab": [
+      [
+        "はな",
+        "はな",
+        "flower / nose"
+      ],
+      [
+        "ひと",
+        "ひと",
+        "person"
+      ],
+      [
+        "ふね",
+        "ふね",
+        "boat / ship"
+      ],
+      [
+        "へた",
+        "へた",
+        "unskillful / bad at"
+      ],
+      [
+        "ほし",
+        "ほし",
+        "star"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: はな ひと ほし. Write 'flower' (はな) and 'star' (ほし) from memory.",
+    "tip": "Soft h-sounds: ha, hi, fu (not 'hu'), he, ho. Get the strokes right!"
+  },
+  {
+    "day": 7,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: ま行 — The M-Series",
+    "intro": "The ま行 (ma-series) brings smooth m-sounds. These characters are fairly easy to distinguish.",
+    "type": "script",
+    "chars": [
+      [
+        "ま",
+        "ma"
+      ],
+      [
+        "み",
+        "mi"
+      ],
+      [
+        "む",
+        "mu"
+      ],
+      [
+        "め",
+        "me"
+      ],
+      [
+        "も",
+        "mo"
+      ]
+    ],
+    "vocab": [
+      [
+        "まち",
+        "まち",
+        "town"
+      ],
+      [
+        "みせ",
+        "みせ",
+        "shop / store"
+      ],
+      [
+        "むし",
+        "むし",
+        "insect / bug"
+      ],
+      [
+        "めし",
+        "めし",
+        "meal / rice (casual)"
+      ],
+      [
+        "もの",
+        "もの",
+        "thing / object"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: まち みせ もの. Can you write 'town' and 'thing' from memory?",
+    "tip": "Even flow: ma, mi, mu, me, mo. めがね (glasses) connects to め looking like an eye!"
+  },
+  {
+    "day": 8,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: や行 — Three Special Characters",
+    "intro": "The や行 (ya-series) has only 3 characters: や, ゆ, よ. These create y-sounds combined with a, u, o.",
+    "type": "script",
+    "chars": [
+      [
+        "や",
+        "ya"
+      ],
+      [
+        "ゆ",
+        "yu"
+      ],
+      [
+        "よ",
+        "yo"
+      ]
+    ],
+    "vocab": [
+      [
+        "やま",
+        "やま",
+        "mountain"
+      ],
+      [
+        "ゆき",
+        "ゆき",
+        "snow"
+      ],
+      [
+        "よこ",
+        "よこ",
+        "beside / sideways"
+      ],
+      [
+        "やさい",
+        "やさい",
+        "vegetable"
+      ],
+      [
+        "ゆみ",
+        "ゆみ",
+        "bow (archery) / Yumi (name)"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: やま ゆき やさい. Write 'mountain' (やま) and 'snow' (ゆき) from memory.",
+    "tip": "Only 3 in this series! ya, yu, yo. These always have the 'y' glide."
+  },
+  {
+    "day": 9,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: ら行 — The R-Series",
+    "intro": "The ら行 (ra-series) completes the basic hiragana. The r-sound is rolled slightly in Japanese.",
+    "type": "script",
+    "chars": [
+      [
+        "ら",
+        "ra"
+      ],
+      [
+        "り",
+        "ri"
+      ],
+      [
+        "る",
+        "ru"
+      ],
+      [
+        "れ",
+        "re"
+      ],
+      [
+        "ろ",
+        "ro"
+      ]
+    ],
+    "vocab": [
+      [
+        "そら",
+        "そら",
+        "sky"
+      ],
+      [
+        "しろ",
+        "しろ",
+        "white / castle"
+      ],
+      [
+        "はる",
+        "はる",
+        "spring (season)"
+      ],
+      [
+        "みる",
+        "みる",
+        "to see / look at"
+      ],
+      [
+        "もり",
+        "もり",
+        "forest"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: そら はる もり. Write 'sky' (そら) and 'forest' (もり) from memory.",
+    "tip": "Softer r-sounds than English: ra, ri, ru, re, ro. Almost between r and l!"
+  },
+  {
+    "day": 10,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: わ、を、ん — The Final Three",
+    "intro": "Today we learn わ, を, and ん. These complete the basic hiragana set: を is almost unused, ん is crucial.",
+    "type": "script",
+    "chars": [
+      [
+        "わ",
+        "wa"
+      ],
+      [
+        "を",
+        "wo/o"
+      ],
+      [
+        "ん",
+        "n"
+      ]
+    ],
+    "vocab": [
+      [
+        "わたし",
+        "わたし",
+        "I / me"
+      ],
+      [
+        "かわ",
+        "かわ",
+        "river"
+      ],
+      [
+        "にわ",
+        "にわ",
+        "garden"
+      ],
+      [
+        "ほん",
+        "ほん",
+        "book"
+      ],
+      [
+        "みんな",
+        "みんな",
+        "everyone"
+      ]
+    ],
+    "grammar": {},
+    "practice": "You now know ALL basic hiragana! Read: わたし かわ ほん みんな. Celebrate — that is huge!",
+    "tip": "ん is magical: it closes any syllable without a vowel! わ sounds like 'wa'. を is almost never used in speech!"
+  },
+  {
+    "day": 11,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: Voiced が行・ざ行",
+    "intro": "Now we add voiced (dakuten) marks! These create g, z, d, b, p sounds from k, s, t, h, m bases.",
+    "type": "script",
+    "chars": [
+      [
+        "が",
+        "ga"
+      ],
+      [
+        "ぎ",
+        "gi"
+      ],
+      [
+        "ぐ",
+        "gu"
+      ],
+      [
+        "げ",
+        "ge"
+      ],
+      [
+        "ご",
+        "go"
+      ],
+      [
+        "ざ",
+        "za"
+      ],
+      [
+        "じ",
+        "ji"
+      ],
+      [
+        "ず",
+        "zu"
+      ],
+      [
+        "ぜ",
+        "ze"
+      ],
+      [
+        "ぞ",
+        "zo"
+      ]
+    ],
+    "vocab": [
+      [
+        "かぎ",
+        "かぎ",
+        "key"
+      ],
+      [
+        "かぜ",
+        "かぜ",
+        "wind / cold (illness)"
+      ],
+      [
+        "ぞう",
+        "ぞう",
+        "elephant"
+      ],
+      [
+        "じかん",
+        "じかん",
+        "time"
+      ],
+      [
+        "がくせい",
+        "がくせい",
+        "student"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: かぎ かぜ ぞう じかん. Notice how adding ﾞ (dakuten) changes the sound!",
+    "tip": "Dakuten (゛) adds voicing: か→が, さ→ざ, た→だ, は→ば. It changes everything!"
+  },
+  {
+    "day": 12,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: Voiced だ行・ば行・ぱ行",
+    "intro": "Continue with more voiced characters plus the semi-voiced (handakuten) ぱ行 marks. Nearly 50 characters now!",
+    "type": "script",
+    "chars": [
+      [
+        "だ",
+        "da"
+      ],
+      [
+        "で",
+        "de"
+      ],
+      [
+        "ど",
+        "do"
+      ],
+      [
+        "ば",
+        "ba"
+      ],
+      [
+        "び",
+        "bi"
+      ],
+      [
+        "ぶ",
+        "bu"
+      ],
+      [
+        "べ",
+        "be"
+      ],
+      [
+        "ぼ",
+        "bo"
+      ],
+      [
+        "ぱ",
+        "pa"
+      ],
+      [
+        "ぴ",
+        "pi"
+      ],
+      [
+        "ぷ",
+        "pu"
+      ],
+      [
+        "ぺ",
+        "pe"
+      ],
+      [
+        "ぽ",
+        "po"
+      ]
+    ],
+    "vocab": [
+      [
+        "でんわ",
+        "でんわ",
+        "telephone"
+      ],
+      [
+        "どうぞ",
+        "どうぞ",
+        "please / go ahead"
+      ],
+      [
+        "からだ",
+        "からだ",
+        "body"
+      ],
+      [
+        "ぼうし",
+        "ぼうし",
+        "hat"
+      ],
+      [
+        "だれ",
+        "だれ",
+        "who?"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: でんわ どうぞ だれ. Practice the voiced (゛) and semi-voiced (゜) sounds.",
+    "tip": "Semi-voiced is special: は→ぱ (adding ゜). Remember: ゛ for g/z/d/b, ゜ only for p!"
+  },
+  {
+    "day": 13,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: Combination Characters (拗音)",
+    "intro": "Combine small や, ゆ, よ with other characters to create palatalized sounds like kya, sho, cha, ryu.",
+    "type": "script",
+    "chars": [
+      [
+        "きゃ",
+        "kya"
+      ],
+      [
+        "きゅ",
+        "kyu"
+      ],
+      [
+        "きょ",
+        "kyo"
+      ],
+      [
+        "しゃ",
+        "sha"
+      ],
+      [
+        "しゅ",
+        "shu"
+      ],
+      [
+        "しょ",
+        "sho"
+      ],
+      [
+        "ちゃ",
+        "cha"
+      ],
+      [
+        "ちゅ",
+        "chu"
+      ],
+      [
+        "ちょ",
+        "cho"
+      ],
+      [
+        "じゃ",
+        "ja"
+      ],
+      [
+        "じゅ",
+        "ju"
+      ],
+      [
+        "じょ",
+        "jo"
+      ],
+      [
+        "りゅ",
+        "ryu"
+      ],
+      [
+        "りょ",
+        "ryo"
+      ]
+    ],
+    "vocab": [
+      [
+        "きょう",
+        "きょう",
+        "today"
+      ],
+      [
+        "しゃしん",
+        "しゃしん",
+        "photograph"
+      ],
+      [
+        "じゃあ",
+        "じゃあ",
+        "well then / OK then"
+      ],
+      [
+        "りょこう",
+        "りょこう",
+        "travel / trip"
+      ],
+      [
+        "びょういん",
+        "びょういん",
+        "hospital"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Read: きょう しゃしん りょこう. Practice saying the small-や/ゆ/よ combos quickly.",
+    "tip": "Combination magic: き+ゃ=きゃ. These are ONE sound, not two! Critical for reading."
+  },
+  {
+    "day": 14,
+    "phaseNum": 1,
+    "phaseName": "Hiragana",
+    "week": 1,
+    "title": "Hiragana: Special Rules & Full Review",
+    "intro": "Master the double consonant (っ) for emphasis and the long vowel mark (ー) used mainly in katakana. Review everything!",
+    "type": "script",
+    "chars": [
+      [
+        "っ",
+        "double"
+      ],
+      [
+        "ー",
+        "long vowel"
+      ]
+    ],
+    "vocab": [
+      [
+        "おかあさん",
+        "おかあさん",
+        "mother"
+      ],
+      [
+        "きって",
+        "きって",
+        "stamp"
+      ],
+      [
+        "がっこう",
+        "がっこう",
+        "school"
+      ],
+      [
+        "ゆっくり",
+        "ゆっくり",
+        "slowly"
+      ],
+      [
+        "ざっし",
+        "ざっし",
+        "magazine"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write the entire hiragana chart from memory. Then read: がっこう、きって、おかあさん",
+    "tip": "っ doubles the next consonant. ー rarely appears in hiragana but very common in katakana!"
+  },
+  {
+    "day": 15,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: ア行 — The 5 Vowels",
+    "intro": "Welcome to katakana! These characters represent the same sounds as hiragana but are used for foreign words.",
+    "type": "script",
+    "chars": [
+      [
+        "ア",
+        "a"
+      ],
+      [
+        "イ",
+        "i"
+      ],
+      [
+        "ウ",
+        "u"
+      ],
+      [
+        "エ",
+        "e"
+      ],
+      [
+        "オ",
+        "o"
+      ]
+    ],
+    "vocab": [
+      [
+        "アイスクリーム",
+        "アイスクリーム",
+        "ice cream"
+      ],
+      [
+        "イタリア",
+        "イタリア",
+        "Italy"
+      ],
+      [
+        "ウイスキー",
+        "ウイスキー",
+        "whisky"
+      ],
+      [
+        "エレベーター",
+        "エレベーター",
+        "elevator"
+      ],
+      [
+        "オレンジ",
+        "オレンジ",
+        "orange"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 10 times. Compare with hiragana—sounds are identical, shapes are angular.",
+    "tip": "Katakana = foreign words, sound effects, emphasis. Learn the angular shapes now!"
+  },
+  {
+    "day": 16,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: カ行 — The K-Series",
+    "intro": "The カ行 in katakana uses the same sounds as か行 but with straighter, more angular strokes.",
+    "type": "script",
+    "chars": [
+      [
+        "カ",
+        "ka"
+      ],
+      [
+        "キ",
+        "ki"
+      ],
+      [
+        "ク",
+        "ku"
+      ],
+      [
+        "ケ",
+        "ke"
+      ],
+      [
+        "コ",
+        "ko"
+      ]
+    ],
+    "vocab": [
+      [
+        "カメラ",
+        "カメラ",
+        "camera"
+      ],
+      [
+        "キッチン",
+        "キッチン",
+        "kitchen"
+      ],
+      [
+        "クラス",
+        "クラス",
+        "class"
+      ],
+      [
+        "ケーキ",
+        "ケーキ",
+        "cake"
+      ],
+      [
+        "コーヒー",
+        "コーヒー",
+        "coffee"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 8 times. Notice the strong angular lines compared to hiragana.",
+    "tip": "Katakana is more geometric! These are loanwords, so sounds might feel foreign at first."
+  },
+  {
+    "day": 17,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: サ行 — The S-Series",
+    "intro": "The サ行 continues the pattern. シ and ス again have special sounds like in hiragana.",
+    "type": "script",
+    "chars": [
+      [
+        "サ",
+        "sa"
+      ],
+      [
+        "シ",
+        "shi"
+      ],
+      [
+        "ス",
+        "su"
+      ],
+      [
+        "セ",
+        "se"
+      ],
+      [
+        "ソ",
+        "so"
+      ]
+    ],
+    "vocab": [
+      [
+        "サッカー",
+        "サッカー",
+        "soccer"
+      ],
+      [
+        "シャツ",
+        "シャツ",
+        "shirt"
+      ],
+      [
+        "スポーツ",
+        "スポーツ",
+        "sports"
+      ],
+      [
+        "セーター",
+        "セーター",
+        "sweater"
+      ],
+      [
+        "ソファ",
+        "ソファ",
+        "sofa"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 8 times. Recognize that these sounds match hiragana exactly.",
+    "tip": "Same sounds, different look! Get comfortable with the angular katakana form."
+  },
+  {
+    "day": 18,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: タ行 — The T-Series",
+    "intro": "The タ行 follows the katakana pattern. チ and ツ retain their special pronunciations.",
+    "type": "script",
+    "chars": [
+      [
+        "タ",
+        "ta"
+      ],
+      [
+        "チ",
+        "chi"
+      ],
+      [
+        "ツ",
+        "tsu"
+      ],
+      [
+        "テ",
+        "te"
+      ],
+      [
+        "ト",
+        "to"
+      ]
+    ],
+    "vocab": [
+      [
+        "タクシー",
+        "タクシー",
+        "taxi"
+      ],
+      [
+        "チケット",
+        "チケット",
+        "ticket"
+      ],
+      [
+        "ツアー",
+        "ツアー",
+        "tour"
+      ],
+      [
+        "テレビ",
+        "テレビ",
+        "TV"
+      ],
+      [
+        "トイレ",
+        "トイレ",
+        "toilet"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 8 times. チ (chi) and ツ (tsu) are instantly recognizable once learned.",
+    "tip": "Notice how チ looks like ちの angular cousin, and ツ is parallel lines—easy to distinguish!"
+  },
+  {
+    "day": 19,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: ナ行 — The N-Series",
+    "intro": "The ナ行 is straightforward with consistent patterns, just like in hiragana.",
+    "type": "script",
+    "chars": [
+      [
+        "ナ",
+        "na"
+      ],
+      [
+        "ニ",
+        "ni"
+      ],
+      [
+        "ヌ",
+        "nu"
+      ],
+      [
+        "ネ",
+        "ne"
+      ],
+      [
+        "ノ",
+        "no"
+      ]
+    ],
+    "vocab": [
+      [
+        "ナイフ",
+        "ナイフ",
+        "knife"
+      ],
+      [
+        "ニュース",
+        "ニュース",
+        "news"
+      ],
+      [
+        "ヌードル",
+        "ヌードル",
+        "noodle"
+      ],
+      [
+        "ネクタイ",
+        "ネクタイ",
+        "necktie"
+      ],
+      [
+        "ノート",
+        "ノート",
+        "notebook"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 8 times. These are simple, regular sounds good for building speed.",
+    "tip": "Consistent sounds: na, ni, nu, ne, no. Perfect for building reading confidence!"
+  },
+  {
+    "day": 20,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: ハ行 — The H-Series",
+    "intro": "The ハ行 maintains the same sounds as hiragana but with the distinctive katakana angular style.",
+    "type": "script",
+    "chars": [
+      [
+        "ハ",
+        "ha"
+      ],
+      [
+        "ヒ",
+        "hi"
+      ],
+      [
+        "フ",
+        "fu"
+      ],
+      [
+        "ヘ",
+        "he"
+      ],
+      [
+        "ホ",
+        "ho"
+      ]
+    ],
+    "vocab": [
+      [
+        "ハンバーガー",
+        "ハンバーガー",
+        "hamburger"
+      ],
+      [
+        "ヒーター",
+        "ヒーター",
+        "heater"
+      ],
+      [
+        "フランス",
+        "フランス",
+        "France"
+      ],
+      [
+        "ヘルメット",
+        "ヘルメット",
+        "helmet"
+      ],
+      [
+        "ホテル",
+        "ホテル",
+        "hotel"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 8 times. Pay attention to the shape of フ (fu)—very distinctive.",
+    "tip": "Angular and strong: ha, hi, fu, he, ho. フ looks like a hook—great memory aid!"
+  },
+  {
+    "day": 21,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: マ行 — The M-Series",
+    "intro": "The マ行 continues with the m-sounds. These characters are fairly distinctive in katakana too.",
+    "type": "script",
+    "chars": [
+      [
+        "マ",
+        "ma"
+      ],
+      [
+        "ミ",
+        "mi"
+      ],
+      [
+        "ム",
+        "mu"
+      ],
+      [
+        "メ",
+        "me"
+      ],
+      [
+        "モ",
+        "mo"
+      ]
+    ],
+    "vocab": [
+      [
+        "マナー",
+        "マナー",
+        "manners"
+      ],
+      [
+        "ミルク",
+        "ミルク",
+        "milk"
+      ],
+      [
+        "ムード",
+        "ムード",
+        "mood"
+      ],
+      [
+        "メニュー",
+        "メニュー",
+        "menu"
+      ],
+      [
+        "モデル",
+        "モデル",
+        "model"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 8 times. メ looks clean and angular, good for quick recall.",
+    "tip": "Smooth m-sounds: ma, mi, mu, me, mo. メ is like a stylized 'me'—clean lines!"
+  },
+  {
+    "day": 22,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: ヤ行 — Three Special Characters",
+    "intro": "The ヤ行 has only 3 characters, just like in hiragana: ヤ, ユ, ヨ with their y-glide sounds.",
+    "type": "script",
+    "chars": [
+      [
+        "ヤ",
+        "ya"
+      ],
+      [
+        "ユ",
+        "yu"
+      ],
+      [
+        "ヨ",
+        "yo"
+      ]
+    ],
+    "vocab": [
+      [
+        "ヤード",
+        "ヤード",
+        "yard"
+      ],
+      [
+        "ユーモア",
+        "ユーモア",
+        "humor"
+      ],
+      [
+        "ヨーロッパ",
+        "ヨーロッパ",
+        "Europe"
+      ],
+      [
+        "ユニフォーム",
+        "ユニフォーム",
+        "uniform"
+      ],
+      [
+        "ヤッホー",
+        "ヤッホー",
+        "yoo-hoo"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 10 times. Remember: still only 3 in this series, same as hiragana.",
+    "tip": "Only 3 again! ya, yu, yo. No ヤ行 for 'i' and 'e'—that's by design!"
+  },
+  {
+    "day": 23,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: ラ行 — The R-Series",
+    "intro": "The ラ行 completes the basic katakana characters. The r-sounds remain gentle, between r and l.",
+    "type": "script",
+    "chars": [
+      [
+        "ラ",
+        "ra"
+      ],
+      [
+        "リ",
+        "ri"
+      ],
+      [
+        "ル",
+        "ru"
+      ],
+      [
+        "レ",
+        "re"
+      ],
+      [
+        "ロ",
+        "ro"
+      ]
+    ],
+    "vocab": [
+      [
+        "ラジオ",
+        "ラジオ",
+        "radio"
+      ],
+      [
+        "リモコン",
+        "リモコン",
+        "remote control"
+      ],
+      [
+        "ルール",
+        "ルール",
+        "rule"
+      ],
+      [
+        "レストラン",
+        "レストラン",
+        "restaurant"
+      ],
+      [
+        "ロビー",
+        "ロビー",
+        "lobby"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 8 times. These angular forms complete the 'basic 5x5'.",
+    "tip": "Softer r-sounds in Japanese: ra, ri, ru, re, ro. You've now learned 50 basic characters!"
+  },
+  {
+    "day": 24,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: ワ行 + Long Vowel Mark",
+    "intro": "The ワ行 in katakana introduces ワ (wa) and ン (n), plus the long vowel mark ー widely used in katakana.",
+    "type": "script",
+    "chars": [
+      [
+        "ワ",
+        "wa"
+      ],
+      [
+        "ン",
+        "n"
+      ],
+      [
+        "ー",
+        "long vowel"
+      ]
+    ],
+    "vocab": [
+      [
+        "ワイン",
+        "ワイン",
+        "wine"
+      ],
+      [
+        "テーブル",
+        "テーブル",
+        "table"
+      ],
+      [
+        "コーヒー",
+        "コーヒー",
+        "coffee"
+      ],
+      [
+        "パン",
+        "パン",
+        "bread"
+      ],
+      [
+        "ランチ",
+        "ランチ",
+        "lunch"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write ワ and ン 10 times. Notice ー extending vowels: コーヒー has two long marks.",
+    "tip": "The dash ー is KEY in katakana! It stretches vowels: コ-ヒー means 'kohiiii'. Essential!"
+  },
+  {
+    "day": 25,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: Voiced ガ行・ザ行",
+    "intro": "Add voiced marks to katakana now! These create g, z sounds, doubling your inventory.",
+    "type": "script",
+    "chars": [
+      [
+        "ガ",
+        "ga"
+      ],
+      [
+        "ギ",
+        "gi"
+      ],
+      [
+        "グ",
+        "gu"
+      ],
+      [
+        "ゲ",
+        "ge"
+      ],
+      [
+        "ゴ",
+        "go"
+      ],
+      [
+        "ザ",
+        "za"
+      ],
+      [
+        "ジ",
+        "ji"
+      ],
+      [
+        "ズ",
+        "zu"
+      ],
+      [
+        "ゼ",
+        "ze"
+      ],
+      [
+        "ゾ",
+        "zo"
+      ]
+    ],
+    "vocab": [
+      [
+        "ゲーム",
+        "ゲーム",
+        "game"
+      ],
+      [
+        "ガイド",
+        "ガイド",
+        "guide"
+      ],
+      [
+        "グループ",
+        "グループ",
+        "group"
+      ],
+      [
+        "ジュース",
+        "ジュース",
+        "juice"
+      ],
+      [
+        "ゾーン",
+        "ゾーン",
+        "zone"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 6 times. Dakuten (゛) works identically on katakana.",
+    "tip": "Same voiced pattern as hiragana! カ→ガ, サ→ザ. The rules are consistent!"
+  },
+  {
+    "day": 26,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: Voiced ダ行・バ行・パ行",
+    "intro": "Continue with more voiced characters and the semi-voiced ぱ行. Nearly there with katakana basics!",
+    "type": "script",
+    "chars": [
+      [
+        "ダ",
+        "da"
+      ],
+      [
+        "デ",
+        "de"
+      ],
+      [
+        "ド",
+        "do"
+      ],
+      [
+        "バ",
+        "ba"
+      ],
+      [
+        "ビ",
+        "bi"
+      ],
+      [
+        "ブ",
+        "bu"
+      ],
+      [
+        "ベ",
+        "be"
+      ],
+      [
+        "ボ",
+        "bo"
+      ],
+      [
+        "パ",
+        "pa"
+      ],
+      [
+        "ピ",
+        "pi"
+      ],
+      [
+        "プ",
+        "pu"
+      ],
+      [
+        "ペ",
+        "pe"
+      ],
+      [
+        "ポ",
+        "po"
+      ]
+    ],
+    "vocab": [
+      [
+        "バス",
+        "バス",
+        "bus"
+      ],
+      [
+        "ピアノ",
+        "ピアノ",
+        "piano"
+      ],
+      [
+        "プール",
+        "プール",
+        "pool"
+      ],
+      [
+        "ペン",
+        "ペン",
+        "pen"
+      ],
+      [
+        "ポスター",
+        "ポスター",
+        "poster"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each character 5 times. Handakuten (゜) creates the p-sound, same as hiragana.",
+    "tip": "Consistent rule: ゛ for g/z/d/b, ゜ for p only. You've mastered this pattern already!"
+  },
+  {
+    "day": 27,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 3,
+    "title": "Katakana: Combinations & Special Sounds",
+    "intro": "Master combination characters with small ヤ, ユ, ヨ, plus special sounds like ファ (fa), ティ (ti).",
+    "type": "script",
+    "chars": [
+      [
+        "シャ",
+        "sha"
+      ],
+      [
+        "チャ",
+        "cha"
+      ],
+      [
+        "ジャ",
+        "ja"
+      ],
+      [
+        "ティ",
+        "ti"
+      ],
+      [
+        "ファ",
+        "fa"
+      ],
+      [
+        "フィ",
+        "fi"
+      ]
+    ],
+    "vocab": [
+      [
+        "シャワー",
+        "シャワー",
+        "shower"
+      ],
+      [
+        "チャンス",
+        "チャンス",
+        "chance"
+      ],
+      [
+        "ジャム",
+        "ジャム",
+        "jam"
+      ],
+      [
+        "ティッシュ",
+        "ティッシュ",
+        "tissue"
+      ],
+      [
+        "ファッション",
+        "ファッション",
+        "fashion"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write each combination 5 times. These blend sounds, creating new phonemes for foreign words.",
+    "tip": "Combinations are ONE sound! シャ=sha, not 'si-ya'. Crucial for loanword reading!"
+  },
+  {
+    "day": 28,
+    "phaseNum": 2,
+    "phaseName": "Katakana",
+    "week": 4,
+    "title": "Katakana: Full Review & Loanword Practice",
+    "intro": "Congratulations! You've learned all basic katakana. Today we practice common loanwords and review the full chart.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "レストラン",
+        "レストラン",
+        "restaurant"
+      ],
+      [
+        "スマートフォン",
+        "スマートフォン",
+        "smartphone"
+      ],
+      [
+        "コンビニ",
+        "コンビニ",
+        "convenience store"
+      ],
+      [
+        "アパート",
+        "アパート",
+        "apartment"
+      ],
+      [
+        "パスポート",
+        "パスポート",
+        "passport"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write the complete katakana chart from memory. Then read: スマートフォン、パスポート、アパート",
+    "tip": "You now read and write 100+ character combinations! Katakana unlocks the loanword world!"
+  },
+  {
+    "day": 29,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 5,
+    "title": "Numbers 1–5",
+    "intro": "Numbers are essential for everything — prices, times, dates. Today: 1 to 5.",
+    "type": "numbers",
+    "chars": [
+      [
+        "いち",
+        "1"
+      ],
+      [
+        "に",
+        "2"
+      ],
+      [
+        "さん",
+        "3"
+      ],
+      [
+        "し/よん",
+        "4"
+      ],
+      [
+        "ご",
+        "5"
+      ]
+    ],
+    "vocab": [
+      [
+        "いちえん",
+        "いちえん",
+        "1 yen"
+      ],
+      [
+        "にほん",
+        "にほん",
+        "2 (long objects)"
+      ],
+      [
+        "さんにん",
+        "さんにん",
+        "3 people"
+      ],
+      [
+        "よにん",
+        "よにん",
+        "4 people"
+      ],
+      [
+        "ごふん",
+        "ごふん",
+        "5 minutes"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜えんです",
+      "meaning": "It is ~ yen",
+      "example_jp": "ひゃくえんです",
+      "example_en": "It is 100 yen"
+    },
+    "practice": "Say 1-5 aloud 10 times. Then count objects around you in Japanese.",
+    "tip": "し(4) can also be read よん — よん is safer as し sounds like 'death'."
+  },
+  {
+    "day": 30,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 5,
+    "title": "Numbers 6–10",
+    "intro": "Completing 1–10 today! These ten numbers unlock prices, ages, and counting.",
+    "type": "numbers",
+    "chars": [
+      [
+        "ろく",
+        "6"
+      ],
+      [
+        "なな/しち",
+        "7"
+      ],
+      [
+        "はち",
+        "8"
+      ],
+      [
+        "きゅう/く",
+        "9"
+      ],
+      [
+        "じゅう",
+        "10"
+      ]
+    ],
+    "vocab": [
+      [
+        "ろっぽん",
+        "ろっぽん",
+        "6 (long objects)"
+      ],
+      [
+        "ななじ",
+        "ななじ",
+        "7 o'clock"
+      ],
+      [
+        "はちえん",
+        "はちえん",
+        "8 yen"
+      ],
+      [
+        "きゅうにん",
+        "きゅうにん",
+        "9 people"
+      ],
+      [
+        "じゅっぷん",
+        "じゅっぷん",
+        "10 minutes"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Count backwards from 10 to 1. Then practice: 3+4=? in Japanese (さん たす よん は なな).",
+    "tip": "なな(7) is safer than しち in some contexts. きゅう(9) is safer than く which means suffering."
+  },
+  {
+    "day": 31,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 5,
+    "title": "Numbers 11–100",
+    "intro": "From 11 onwards, Japanese numbers are logical: 11 = ten-one (じゅういち).",
+    "type": "numbers",
+    "chars": [
+      [
+        "じゅういち",
+        "11"
+      ],
+      [
+        "じゅうに",
+        "12"
+      ],
+      [
+        "にじゅう",
+        "20"
+      ],
+      [
+        "さんじゅう",
+        "30"
+      ],
+      [
+        "ひゃく",
+        "100"
+      ]
+    ],
+    "vocab": [
+      [
+        "じゅうごえん",
+        "じゅうごえん",
+        "15 yen"
+      ],
+      [
+        "にじゅうさい",
+        "にじゅうさい",
+        "20 years old"
+      ],
+      [
+        "さんじゅうにん",
+        "さんじゅうにん",
+        "30 people"
+      ],
+      [
+        "ごじゅっぷん",
+        "ごじゅっぷん",
+        "50 minutes"
+      ],
+      [
+        "ひゃくえん",
+        "ひゃくえん",
+        "100 yen"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Write out: 13, 27, 45, 68, 99 in Japanese. Check your answers.",
+    "tip": "The pattern is simple: tens digit + じゅう + ones digit. 47 = よんじゅうなな. No exceptions!"
+  },
+  {
+    "day": 32,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 5,
+    "title": "Numbers: Hundreds & Thousands",
+    "intro": "Big numbers! 100=ひゃく, 1000=せん, 10000=まん. Japan uses まん (10,000) as a unit.",
+    "type": "numbers",
+    "chars": [
+      [
+        "ひゃく",
+        "100"
+      ],
+      [
+        "せん",
+        "1,000"
+      ],
+      [
+        "まん",
+        "10,000"
+      ],
+      [
+        "いちまん",
+        "10,000"
+      ],
+      [
+        "じゅうまん",
+        "100,000"
+      ]
+    ],
+    "vocab": [
+      [
+        "さんびゃくえん",
+        "さんびゃくえん",
+        "300 yen"
+      ],
+      [
+        "ごせんえん",
+        "ごせんえん",
+        "5,000 yen"
+      ],
+      [
+        "いちまんえん",
+        "いちまんえん",
+        "10,000 yen"
+      ],
+      [
+        "にまんごせん",
+        "にまんごせん",
+        "25,000"
+      ],
+      [
+        "ひゃくまん",
+        "ひゃくまん",
+        "1,000,000"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Practice saying prices: ¥350, ¥1,200, ¥15,000, ¥98,000.",
+    "tip": "Note: 300=さんびゃく, 600=ろっぴゃく, 800=はっぴゃく (irregular!). 3000=さんぜん, 8000=はっせん."
+  },
+  {
+    "day": 33,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 5,
+    "title": "Counters: まい・ほん・ひき",
+    "intro": "Japanese uses special counters depending on what's being counted. Today: flat things, long things, small animals.",
+    "type": "numbers",
+    "chars": [
+      [
+        "〜まい",
+        "flat things"
+      ],
+      [
+        "〜ほん",
+        "long thin things"
+      ],
+      [
+        "〜ひき",
+        "small animals"
+      ],
+      [
+        "〜だい",
+        "machines"
+      ],
+      [
+        "〜さつ",
+        "bound books"
+      ]
+    ],
+    "vocab": [
+      [
+        "かみ　いちまい",
+        "かみ　いちまい",
+        "1 sheet of paper"
+      ],
+      [
+        "えんぴつ　にほん",
+        "えんぴつ　にほん",
+        "2 pencils"
+      ],
+      [
+        "ねこ　さんびき",
+        "ねこ　さんびき",
+        "3 cats"
+      ],
+      [
+        "くるま　よんだい",
+        "くるま　よんだい",
+        "4 cars"
+      ],
+      [
+        "ほん　ごさつ",
+        "ほん　ごさつ",
+        "5 books"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　Nまい　ください",
+      "meaning": "Please give me N (flat things)",
+      "example_jp": "きって　を　にまい　ください",
+      "example_en": "Please give me 2 stamps"
+    },
+    "practice": "Count: 3 sheets of paper, 2 pens, 4 cats, 1 car, 5 books — in Japanese.",
+    "tip": "Counters cause sound changes: 1 pencil = いっぽん, 6 pencils = ろっぽん, 8 = はっぽん. Listen and repeat!"
+  },
+  {
+    "day": 34,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 5,
+    "title": "Counters: 〜つ・〜個・人",
+    "intro": "Generic counter 〜つ works for most objects (1-10 only). 〜こ for small objects. 〜にん for people.",
+    "type": "numbers",
+    "chars": [
+      [
+        "ひとつ",
+        "1 (general)"
+      ],
+      [
+        "ふたつ",
+        "2 (general)"
+      ],
+      [
+        "みっつ",
+        "3"
+      ],
+      [
+        "よっつ",
+        "4"
+      ],
+      [
+        "いつつ",
+        "5"
+      ]
+    ],
+    "vocab": [
+      [
+        "むっつ",
+        "むっつ",
+        "6 (general)"
+      ],
+      [
+        "ななつ",
+        "ななつ",
+        "7"
+      ],
+      [
+        "やっつ",
+        "やっつ",
+        "8"
+      ],
+      [
+        "ここのつ",
+        "ここのつ",
+        "9"
+      ],
+      [
+        "とお",
+        "とお",
+        "10"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Nにん",
+      "meaning": "N people",
+      "example_jp": "かぞくは　よにんです",
+      "example_en": "My family has 4 people"
+    },
+    "practice": "Memorize ひとつ through とお. They're irregular but very common in daily speech.",
+    "tip": "ひとつ～とお are native Japanese numbers (和語). They're used for general counting up to 10. Beyond 10, use じゅういち style."
+  },
+  {
+    "day": 35,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 5,
+    "title": "Numbers Review & Prices",
+    "intro": "Putting numbers into real-world context: shopping, prices, ages.",
+    "type": "numbers",
+    "chars": [],
+    "vocab": [
+      [
+        "いくらですか",
+        "いくらですか",
+        "How much is it?"
+      ],
+      [
+        "〜えんです",
+        "〜えんです",
+        "It is ~ yen"
+      ],
+      [
+        "たかい",
+        "たかい",
+        "expensive"
+      ],
+      [
+        "やすい",
+        "やすい",
+        "cheap"
+      ],
+      [
+        "おつり",
+        "おつり",
+        "change (money)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜えんです",
+      "meaning": "It is ~ yen",
+      "example_jp": "これは　さんびゃくえんです",
+      "example_en": "This is 300 yen"
+    },
+    "practice": "Practice: How would you say ¥480? ¥1,350? ¥22,000? Write them out in Japanese.",
+    "tip": "In Japan, tax (消費税 しょうひぜい) is added at checkout. Prices on tags are often before tax!"
+  },
+  {
+    "day": 36,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 6,
+    "title": "Telling Time: Hours",
+    "intro": "〜じ = o'clock. いちじ=1:00, にじ=2:00... Learn to tell time on the hour.",
+    "type": "lesson",
+    "chars": [
+      [
+        "〜じ",
+        "o'clock"
+      ],
+      [
+        "なんじ",
+        "what time"
+      ],
+      [
+        "ごぜん",
+        "AM"
+      ],
+      [
+        "ごご",
+        "PM"
+      ],
+      [
+        "はん",
+        "half past"
+      ]
+    ],
+    "vocab": [
+      [
+        "いちじ",
+        "いちじ",
+        "1 o'clock"
+      ],
+      [
+        "さんじはん",
+        "さんじはん",
+        "3:30"
+      ],
+      [
+        "ごぜんくじ",
+        "ごぜんくじ",
+        "9 AM"
+      ],
+      [
+        "ごごにじ",
+        "ごごにじ",
+        "2 PM"
+      ],
+      [
+        "なんじですか",
+        "なんじですか",
+        "What time is it?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "いま　なんじですか",
+      "meaning": "What time is it now?",
+      "example_jp": "いま　ごぜん　じゅうじです",
+      "example_en": "It is 10 AM now"
+    },
+    "practice": "Practice saying these times: 7:00, 12:00, 3:30, 6:00 PM, 11:30 PM.",
+    "tip": "4 o'clock = よじ (not しじ!). 9 o'clock = くじ. These two are irregular — memorise them."
+  },
+  {
+    "day": 37,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 6,
+    "title": "Telling Time: Minutes",
+    "intro": "〜ふん/ぷん = minutes. Combined with hours: さんじごふん = 3:05.",
+    "type": "lesson",
+    "chars": [
+      [
+        "〜ふん",
+        "minutes"
+      ],
+      [
+        "〜ぷん",
+        "minutes (after certain numbers)"
+      ],
+      [
+        "なんぷん",
+        "how many minutes"
+      ],
+      [
+        "ちょうど",
+        "exactly"
+      ],
+      [
+        "ごろ",
+        "approximately"
+      ]
+    ],
+    "vocab": [
+      [
+        "さんじごふん",
+        "さんじごふん",
+        "3:05"
+      ],
+      [
+        "じゅうにじよんじゅっぷん",
+        "じゅうにじよんじゅっぷん",
+        "12:40"
+      ],
+      [
+        "しちじはん",
+        "しちじはん",
+        "7:30"
+      ],
+      [
+        "ごごくじじゅうごふん",
+        "ごごくじじゅうごふん",
+        "9:15 PM"
+      ],
+      [
+        "ちょうどじゅうじ",
+        "ちょうどじゅうじ",
+        "exactly 10:00"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜じ　〜ふんです",
+      "meaning": "It is ~h ~min",
+      "example_jp": "にじ　さんじゅっぷんです",
+      "example_en": "It is 2:30"
+    },
+    "practice": "Practice reading these times: 8:15, 10:45, 1:20, 6:55, 11:30.",
+    "tip": "Minutes with sound changes: 1min=いっぷん, 6=ろっぷん, 8=はっぷん, 10=じゅっぷん. The rest use ふん."
+  },
+  {
+    "day": 38,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 6,
+    "title": "Yesterday, Today, Tomorrow",
+    "intro": "Core time words for daily conversation. Also: morning/afternoon/evening.",
+    "type": "lesson",
+    "chars": [
+      [
+        "きのう",
+        "yesterday"
+      ],
+      [
+        "きょう",
+        "today"
+      ],
+      [
+        "あした",
+        "tomorrow"
+      ],
+      [
+        "あさ",
+        "morning"
+      ],
+      [
+        "よる",
+        "night"
+      ]
+    ],
+    "vocab": [
+      [
+        "おととい",
+        "おととい",
+        "the day before yesterday"
+      ],
+      [
+        "あさって",
+        "あさって",
+        "the day after tomorrow"
+      ],
+      [
+        "ひるごろ",
+        "ひるごろ",
+        "around noon"
+      ],
+      [
+        "まいにち",
+        "まいにち",
+        "every day"
+      ],
+      [
+        "いつ",
+        "いつ",
+        "when"
+      ]
+    ],
+    "grammar": {
+      "pattern": "いつ　〜ますか",
+      "meaning": "When will you ~?",
+      "example_jp": "いつ　にほんへ　いきますか",
+      "example_en": "When will you go to Japan?"
+    },
+    "practice": "Make sentences: What did you do yesterday? What will you do tomorrow?",
+    "tip": "きょう、あした、あさって — each adds a day. きのう、おととい — each goes back a day. Simple pattern!"
+  },
+  {
+    "day": 39,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 6,
+    "title": "Days of the Week",
+    "intro": "The 7 days all end in ようび. Each is named after a natural element.",
+    "type": "lesson",
+    "chars": [
+      [
+        "にちようび",
+        "Sunday (sun)"
+      ],
+      [
+        "げつようび",
+        "Monday (moon)"
+      ],
+      [
+        "かようび",
+        "Tuesday (fire)"
+      ],
+      [
+        "すいようび",
+        "Wednesday (water)"
+      ],
+      [
+        "もくようび",
+        "Thursday (wood)"
+      ]
+    ],
+    "vocab": [
+      [
+        "きんようび",
+        "きんようび",
+        "Friday (gold)"
+      ],
+      [
+        "どようび",
+        "どようび",
+        "Saturday (earth)"
+      ],
+      [
+        "なんようびですか",
+        "なんようびですか",
+        "What day is it?"
+      ],
+      [
+        "らいしゅう",
+        "らいしゅう",
+        "next week"
+      ],
+      [
+        "せんしゅう",
+        "せんしゅう",
+        "last week"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ようびに　〜します",
+      "meaning": "On ~ day, I will ~",
+      "example_jp": "きんようびに　えいがを　みます",
+      "example_en": "On Friday, I'll watch a movie"
+    },
+    "practice": "Memorize the order: 日月火水木金土. Say them as a rhythm: ni-chi-ge-tsu-ka-sui-moku-kin-do.",
+    "tip": "Memory trick: Sun-Moon-Fire-Water-Wood-Gold-Earth. Each day is named after a celestial body or element!"
+  },
+  {
+    "day": 40,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 6,
+    "title": "Months of the Year",
+    "intro": "Simple! Just number + がつ. いちがつ=January, にがつ=February, etc.",
+    "type": "lesson",
+    "chars": [
+      [
+        "いちがつ",
+        "January"
+      ],
+      [
+        "にがつ",
+        "February"
+      ],
+      [
+        "さんがつ",
+        "March"
+      ],
+      [
+        "しがつ",
+        "April"
+      ],
+      [
+        "ごがつ",
+        "May"
+      ]
+    ],
+    "vocab": [
+      [
+        "ろくがつ",
+        "ろくがつ",
+        "June"
+      ],
+      [
+        "しちがつ",
+        "しちがつ",
+        "July"
+      ],
+      [
+        "はちがつ",
+        "はちがつ",
+        "August"
+      ],
+      [
+        "くがつ",
+        "くがつ",
+        "September"
+      ],
+      [
+        "じゅうがつ",
+        "じゅうがつ",
+        "October"
+      ],
+      [
+        "じゅういちがつ",
+        "じゅういちがつ",
+        "November"
+      ],
+      [
+        "じゅうにがつ",
+        "じゅうにがつ",
+        "December"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜がつ　〜にち",
+      "meaning": "Month ~ Day ~",
+      "example_jp": "さんがつ　みっかです",
+      "example_en": "It is March 3rd"
+    },
+    "practice": "What month is your birthday? Say it in Japanese. What month is it now?",
+    "tip": "No exceptions! Every month is just number+がつ. Much easier than English month names!"
+  },
+  {
+    "day": 41,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 6,
+    "title": "Dates: Day Numbers",
+    "intro": "Days of the month use special readings for 1-10 and 14, 20, 24.",
+    "type": "lesson",
+    "chars": [
+      [
+        "ついたち",
+        "1st"
+      ],
+      [
+        "ふつか",
+        "2nd"
+      ],
+      [
+        "みっか",
+        "3rd"
+      ],
+      [
+        "よっか",
+        "4th"
+      ],
+      [
+        "いつか",
+        "5th"
+      ]
+    ],
+    "vocab": [
+      [
+        "むいか",
+        "むいか",
+        "6th"
+      ],
+      [
+        "なのか",
+        "なのか",
+        "7th"
+      ],
+      [
+        "ようか",
+        "ようか",
+        "8th"
+      ],
+      [
+        "ここのか",
+        "ここのか",
+        "9th"
+      ],
+      [
+        "とおか",
+        "とおか",
+        "10th"
+      ],
+      [
+        "じゅうよっか",
+        "じゅうよっか",
+        "14th"
+      ],
+      [
+        "はつか",
+        "はつか",
+        "20th"
+      ],
+      [
+        "にじゅうよっか",
+        "にじゅうよっか",
+        "24th"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜がつ　〜にちです",
+      "meaning": "It is ~ month, ~ day",
+      "example_jp": "たんじょうびは　しちがつ　ここのかです",
+      "example_en": "My birthday is July 9th"
+    },
+    "practice": "Memorise the special readings: 1st-10th, 14th, 20th, 24th. The rest use にち (e.g. じゅうごにち=15th).",
+    "tip": "Most days = number+にち. But 1-10 are native Japanese readings (ついたち、ふつか...) — these MUST be memorised!"
+  },
+  {
+    "day": 42,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 6,
+    "title": "Time & Date Review",
+    "intro": "Putting together time, days, months and dates in real sentences.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "らいしゅうの　もくようび",
+        "らいしゅうの　もくようび",
+        "next Thursday"
+      ],
+      [
+        "ごがつ　いつか",
+        "ごがつ　いつか",
+        "May 5th"
+      ],
+      [
+        "ごごさんじはん",
+        "ごごさんじはん",
+        "3:30 PM"
+      ],
+      [
+        "まいあさ　ろくじ",
+        "まいあさ　ろくじ",
+        "every morning at 6"
+      ],
+      [
+        "〜からです",
+        "〜からです",
+        "it starts from ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜から　〜まで",
+      "meaning": "from ~ until ~",
+      "example_jp": "くじから　ごじまで　はたらきます",
+      "example_en": "I work from 9 to 5"
+    },
+    "practice": "Write your daily schedule in Japanese: wake up time, school/work hours, sleep time.",
+    "tip": "Combine everything: ごがつ みっか（かようび）の　ごごにじはんに　あいましょう！ (Let's meet on Tuesday, May 3rd at 2:30 PM!)"
+  },
+  {
+    "day": 43,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 7,
+    "title": "Basic Greetings",
+    "intro": "The essential Japanese greetings you'll use every single day.",
+    "type": "lesson",
+    "chars": [
+      [
+        "おはようございます",
+        "good morning (polite)"
+      ],
+      [
+        "こんにちは",
+        "good afternoon/hello"
+      ],
+      [
+        "こんばんは",
+        "good evening"
+      ],
+      [
+        "おやすみなさい",
+        "good night"
+      ],
+      [
+        "さようなら",
+        "goodbye"
+      ]
+    ],
+    "vocab": [
+      [
+        "おはよう",
+        "おはよう",
+        "good morning (casual)"
+      ],
+      [
+        "じゃあね",
+        "じゃあね",
+        "see ya (casual)"
+      ],
+      [
+        "またあした",
+        "またあした",
+        "see you tomorrow"
+      ],
+      [
+        "いってきます",
+        "いってきます",
+        "I'm heading out"
+      ],
+      [
+        "いってらっしゃい",
+        "いってらっしゃい",
+        "Have a safe trip (response)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "おはようございます",
+      "meaning": "Good morning (polite)",
+      "example_jp": "おはようございます！きょうもよろしくおねがいします",
+      "example_en": "Good morning! I look forward to working with you today"
+    },
+    "practice": "Practice greeting sequences: morning → afternoon → evening → night. Also the いってきます/いってらっしゃい pair.",
+    "tip": "Japanese greetings change by time of day. おはよう before ~10am, こんにちは ~10am-6pm, こんばんは after ~6pm."
+  },
+  {
+    "day": 44,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 7,
+    "title": "Polite Expressions",
+    "intro": "Thank you, excuse me, sorry — the essential politeness toolkit.",
+    "type": "lesson",
+    "chars": [
+      [
+        "ありがとうございます",
+        "thank you (polite)"
+      ],
+      [
+        "すみません",
+        "excuse me / sorry"
+      ],
+      [
+        "もうしわけありません",
+        "I am very sorry"
+      ],
+      [
+        "どういたしまして",
+        "you're welcome"
+      ],
+      [
+        "おねがいします",
+        "please (requesting)"
+      ]
+    ],
+    "vocab": [
+      [
+        "ありがとう",
+        "ありがとう",
+        "thank you (casual)"
+      ],
+      [
+        "ごめんなさい",
+        "ごめんなさい",
+        "I'm sorry"
+      ],
+      [
+        "だいじょうぶです",
+        "だいじょうぶです",
+        "It's OK / I'm fine"
+      ],
+      [
+        "はい",
+        "はい",
+        "yes"
+      ],
+      [
+        "いいえ",
+        "いいえ",
+        "no"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　おねがいします",
+      "meaning": "Please (give me / do) ~",
+      "example_jp": "コーヒーを　おねがいします",
+      "example_en": "A coffee please"
+    },
+    "practice": "Role-play: bump into someone (すみません), receive a gift (ありがとうございます), someone thanks you (どういたしまして).",
+    "tip": "すみません is incredibly versatile — use it to get attention, apologize mildly, or say 'excuse me'. One of Japan's most used words!"
+  },
+  {
+    "day": 45,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 7,
+    "title": "Self Introduction",
+    "intro": "はじめまして！Learn how to introduce yourself in Japanese.",
+    "type": "lesson",
+    "chars": [
+      [
+        "はじめまして",
+        "nice to meet you"
+      ],
+      [
+        "〜といいます",
+        "my name is ~"
+      ],
+      [
+        "〜からきました",
+        "I'm from ~"
+      ],
+      [
+        "〜をしています",
+        "I work as / I do ~"
+      ],
+      [
+        "よろしくおねがいします",
+        "pleased to meet you"
+      ]
+    ],
+    "vocab": [
+      [
+        "わたしは〜です",
+        "わたしは〜です",
+        "I am ~"
+      ],
+      [
+        "しゅっしんは〜です",
+        "しゅっしんは〜です",
+        "I'm from ~ (hometown)"
+      ],
+      [
+        "しごとは〜です",
+        "しごとは〜です",
+        "My job is ~"
+      ],
+      [
+        "しゅみは〜です",
+        "しゅみは〜です",
+        "My hobby is ~"
+      ],
+      [
+        "よろしく",
+        "よろしく",
+        "nice to meet you (casual)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "はじめまして。〜といいます",
+      "meaning": "Nice to meet you. My name is ~",
+      "example_jp": "はじめまして。アランといいます。アメリカからきました。よろしくおねがいします",
+      "example_en": "Nice to meet you. My name is Alan. I'm from America. Pleased to meet you"
+    },
+    "practice": "Write your own self-introduction: name, country, occupation/study, hobby. Memorise it!",
+    "tip": "〜といいます is more humble than 〜です for your name. Always end with よろしくおねがいします — it's essential etiquette!"
+  },
+  {
+    "day": 46,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 7,
+    "title": "At a Shop / Restaurant",
+    "intro": "Essential phrases for shopping and dining — phrases you'll need in Japan!",
+    "type": "lesson",
+    "chars": [
+      [
+        "いらっしゃいませ",
+        "welcome (shop/restaurant)"
+      ],
+      [
+        "〜をください",
+        "please give me ~"
+      ],
+      [
+        "いくらですか",
+        "how much is it?"
+      ],
+      [
+        "〜をひとつ",
+        "one of ~"
+      ],
+      [
+        "おかいけい",
+        "the bill / check"
+      ]
+    ],
+    "vocab": [
+      [
+        "メニューをみせてください",
+        "メニューをみせてください",
+        "Please show me the menu"
+      ],
+      [
+        "これにします",
+        "これにします",
+        "I'll have this"
+      ],
+      [
+        "おすすめは？",
+        "おすすめは？",
+        "What do you recommend?"
+      ],
+      [
+        "テイクアウトで",
+        "テイクアウトで",
+        "To go / takeaway"
+      ],
+      [
+        "カードでもいいですか",
+        "カードでもいいですか",
+        "Can I pay by card?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　ひとつ　ください",
+      "meaning": "One ~ please",
+      "example_jp": "コーヒーを　ふたつ　ください",
+      "example_en": "Two coffees please"
+    },
+    "practice": "Practise ordering: a coffee, two sandwiches, and asking for the bill. Role-play at a restaurant.",
+    "tip": "You don't need to say 'I want' in Japanese — just say the item + をください. Much more direct than English!"
+  },
+  {
+    "day": 47,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 7,
+    "title": "Asking for Help",
+    "intro": "Can't understand? Need directions? These phrases will save you.",
+    "type": "lesson",
+    "chars": [
+      [
+        "わかりません",
+        "I don't understand"
+      ],
+      [
+        "もういちど　いってください",
+        "please say it again"
+      ],
+      [
+        "ゆっくり　はなしてください",
+        "please speak slowly"
+      ],
+      [
+        "〜はどこですか",
+        "where is ~?"
+      ],
+      [
+        "〜をしっていますか",
+        "do you know ~?"
+      ]
+    ],
+    "vocab": [
+      [
+        "えいごが　わかりますか",
+        "えいごが　わかりますか",
+        "Do you understand English?"
+      ],
+      [
+        "かいてください",
+        "かいてください",
+        "Please write it"
+      ],
+      [
+        "おしえてください",
+        "おしえてください",
+        "Please tell/teach me"
+      ],
+      [
+        "たすけてください",
+        "たすけてください",
+        "Please help me"
+      ],
+      [
+        "きんきゅうじたい",
+        "きんきゅうじたい",
+        "emergency"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　どこですか",
+      "meaning": "Where is ~?",
+      "example_jp": "トイレは　どこですか",
+      "example_en": "Where is the bathroom?"
+    },
+    "practice": "Practice: 'I don't understand, please repeat slowly' and 'Where is the station?' until smooth.",
+    "tip": "Don't be embarrassed to use わかりません！Japanese people appreciate the effort to communicate even imperfectly."
+  },
+  {
+    "day": 48,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 7,
+    "title": "Daily Life Phrases",
+    "intro": "Common phrases for school, work, and everyday situations.",
+    "type": "lesson",
+    "chars": [
+      [
+        "おはようございます",
+        "good morning (at work/school)"
+      ],
+      [
+        "おつかれさまでした",
+        "good work / thanks for your effort"
+      ],
+      [
+        "いただきます",
+        "let's eat (before meals)"
+      ],
+      [
+        "ごちそうさまでした",
+        "thank you for the meal (after)"
+      ],
+      [
+        "しつれいします",
+        "excuse me / I'm leaving"
+      ]
+    ],
+    "vocab": [
+      [
+        "ちょっとまってください",
+        "ちょっとまってください",
+        "Please wait a moment"
+      ],
+      [
+        "あとで",
+        "あとで",
+        "later"
+      ],
+      [
+        "いそいでいます",
+        "いそいでいます",
+        "I'm in a hurry"
+      ],
+      [
+        "もちろん",
+        "もちろん",
+        "of course"
+      ],
+      [
+        "たぶん",
+        "たぶん",
+        "probably / maybe"
+      ]
+    ],
+    "grammar": {
+      "pattern": "おつかれさまでした",
+      "meaning": "Thank you for your hard work",
+      "example_jp": "きょうも　おつかれさまでした！",
+      "example_en": "Good work today!"
+    },
+    "practice": "Practise the meal phrases いただきます and ごちそうさまでした — these are required etiquette in Japan!",
+    "tip": "いただきます and ごちそうさまでした have no direct English translation. They express gratitude for the food and everyone who prepared it."
+  },
+  {
+    "day": 49,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 7,
+    "title": "Greetings Review",
+    "intro": "Review all greetings and expressions from this week in context.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "おはようございます",
+        "おはようございます",
+        "good morning"
+      ],
+      [
+        "ありがとうございます",
+        "ありがとうございます",
+        "thank you"
+      ],
+      [
+        "すみません",
+        "すみません",
+        "excuse me"
+      ],
+      [
+        "はじめまして",
+        "はじめまして",
+        "nice to meet you"
+      ],
+      [
+        "よろしくおねがいします",
+        "よろしくおねがいします",
+        "pleased to meet you"
+      ],
+      [
+        "ふくしゅう",
+        "ふくしゅう",
+        "review (going back over what you've learned)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "はじめまして。〜です。よろしくおねがいします",
+      "meaning": "Full introduction pattern",
+      "example_jp": "はじめまして。マリアです。スペインからきました。よろしくおねがいします",
+      "example_en": "Nice to meet you. I'm Maria. I'm from Spain. Pleased to meet you"
+    },
+    "practice": "Write and memorise a complete self-introduction in Japanese (5-6 sentences).",
+    "tip": "Consistency is key! Practice your self-introduction until it flows naturally — you'll use it many times in Japan."
+  },
+  {
+    "day": 50,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 8,
+    "title": "Topic Particle は",
+    "intro": "は marks the topic of the sentence. X は Y です = X is Y. This is the most fundamental sentence pattern.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしは　がくせいです",
+        "わたしは　がくせいです",
+        "I am a student"
+      ],
+      [
+        "これは　ほんです",
+        "これは　ほんです",
+        "This is a book"
+      ],
+      [
+        "かれは　せんせいです",
+        "かれは　せんせいです",
+        "He is a teacher"
+      ],
+      [
+        "にほんは　くにです",
+        "にほんは　くにです",
+        "Japan is a country"
+      ],
+      [
+        "これは　なんですか",
+        "これは　なんですか",
+        "What is this?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "X は Y です",
+      "meaning": "X is Y (X is the topic)",
+      "example_jp": "わたしは　にほんごの　がくせいです",
+      "example_en": "I am a student of Japanese"
+    },
+    "practice": "Make 5 sentences using XはYです about yourself and things around you.",
+    "tip": "は is pronounced 'wa' when used as a particle! It's spelled は (ha) but read as 'wa'. Classic Japanese quirk!"
+  },
+  {
+    "day": 51,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 8,
+    "title": "Negative: じゃないです",
+    "intro": "X は Y じゃないです = X is not Y. The polite negative of です.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしは　せんせいじゃないです",
+        "わたしは　せんせいじゃないです",
+        "I am not a teacher"
+      ],
+      [
+        "これは　ほんじゃないです",
+        "これは　ほんじゃないです",
+        "This is not a book"
+      ],
+      [
+        "かれは　がくせいじゃないです",
+        "かれは　がくせいじゃないです",
+        "He is not a student"
+      ],
+      [
+        "にほんごは　むずかしくないです",
+        "にほんごは　むずかしくないです",
+        "Japanese is not difficult"
+      ],
+      [
+        "あれは　くるまじゃないです",
+        "あれは　くるまじゃないです",
+        "That is not a car"
+      ]
+    ],
+    "grammar": {
+      "pattern": "X は Y じゃないです",
+      "meaning": "X is not Y",
+      "example_jp": "これは　コーヒーじゃないです。おちゃです",
+      "example_en": "This is not coffee. It is tea"
+    },
+    "practice": "Negate 5 sentences from yesterday's practice. Then try mixing positive and negative in one paragraph.",
+    "tip": "More formal version: ではありません (de wa arimasen). じゃないです is fine for most situations. ではありません for formal writing."
+  },
+  {
+    "day": 52,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 8,
+    "title": "Questions with か",
+    "intro": "Adding か to the end of a statement makes it a yes/no question. そうです = That's right. ちがいます = That's wrong.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "がくせいですか",
+        "がくせいですか",
+        "Are you a student?"
+      ],
+      [
+        "はい、そうです",
+        "はい、そうです",
+        "Yes, that's right"
+      ],
+      [
+        "いいえ、ちがいます",
+        "いいえ、ちがいます",
+        "No, that's not right"
+      ],
+      [
+        "これは　なんですか",
+        "これは　なんですか",
+        "What is this?"
+      ],
+      [
+        "なんさいですか",
+        "なんさいですか",
+        "How old are you?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ですか",
+      "meaning": "Is it ~? / Are you ~?",
+      "example_jp": "にほんじんですか。いいえ、アメリカじんです",
+      "example_en": "Are you Japanese? No, I'm American"
+    },
+    "practice": "Practice Q&A: ask a partner (or yourself!) 5 questions using ですか and answer them.",
+    "tip": "In casual speech, か is often dropped and replaced by a rising intonation: がくせい？ (Are you a student?) — but です or ます must still be there in polite speech."
+  },
+  {
+    "day": 53,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 8,
+    "title": "Particle も — also/too",
+    "intro": "も replaces は (or が/を) to mean 'also' or 'too'. Very simple and very useful.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしも　がくせいです",
+        "わたしも　がくせいです",
+        "I am also a student"
+      ],
+      [
+        "これも　ほんです",
+        "これも　ほんです",
+        "This is also a book"
+      ],
+      [
+        "やまださんも　にほんじんです",
+        "やまださんも　にほんじんです",
+        "Yamada-san is also Japanese"
+      ],
+      [
+        "コーヒーも　おちゃも　すきです",
+        "コーヒーも　おちゃも　すきです",
+        "I like both coffee and tea"
+      ],
+      [
+        "わたしも！",
+        "わたしも！",
+        "Me too!"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜も〜です",
+      "meaning": "~ is also ~",
+      "example_jp": "かのじょも　いしゃです",
+      "example_en": "She is also a doctor"
+    },
+    "practice": "Make 3 sentences using も to connect two similar ideas or add 'me too' to a conversation.",
+    "tip": "Xも Yも = both X and Y. This is a great way to list things inclusively in Japanese!"
+  },
+  {
+    "day": 54,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 8,
+    "title": "Occupations Vocabulary",
+    "intro": "Essential job and role vocabulary for introductions and conversations.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "がくせい",
+        "がくせい",
+        "student"
+      ],
+      [
+        "せんせい",
+        "せんせい",
+        "teacher"
+      ],
+      [
+        "かいしゃいん",
+        "かいしゃいん",
+        "office worker"
+      ],
+      [
+        "いしゃ",
+        "いしゃ",
+        "doctor"
+      ],
+      [
+        "エンジニア",
+        "エンジニア",
+        "engineer"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　しています",
+      "meaning": "I work as / I do ~",
+      "example_jp": "わたしは　エンジニアを　しています",
+      "example_en": "I work as an engineer"
+    },
+    "practice": "Learn 10 occupations. Can you describe what 5 different people do, using は and です?",
+    "tip": "〜をしています is more natural than just 〜です for jobs. かいしゃいん is a generic term for any company employee — very common in Japan!"
+  },
+  {
+    "day": 55,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 8,
+    "title": "Nationalities & Countries",
+    "intro": "〜じん = person from ~. 〜ご = language of ~. にほん→にほんじん、にほんご.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "にほんじん",
+        "にほんじん",
+        "Japanese person"
+      ],
+      [
+        "アメリカじん",
+        "アメリカじん",
+        "American person"
+      ],
+      [
+        "イギリスじん",
+        "イギリスじん",
+        "British person"
+      ],
+      [
+        "ちゅうごくじん",
+        "ちゅうごくじん",
+        "Chinese person"
+      ],
+      [
+        "にほんご",
+        "にほんご",
+        "Japanese language"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜じんです",
+      "meaning": "I am ~ (nationality)",
+      "example_jp": "わたしは　アメリカじんです。えいごを　はなします",
+      "example_en": "I am American. I speak English"
+    },
+    "practice": "What is your nationality? What languages do you speak? Write 3 sentences.",
+    "tip": "The suffix じん means 'person from'. ご means 'language of'. So にほんご = Japanese language, ちゅうごくご = Chinese language!"
+  },
+  {
+    "day": 56,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 8,
+    "title": "は Particle Review & Dialogue",
+    "intro": "Putting it all together: introductions using は, じゃないです, ですか, も.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしのなまえは〜です",
+        "わたしのなまえは〜です",
+        "My name is ~"
+      ],
+      [
+        "どちらから　いらっしゃいましたか",
+        "どちらから　いらっしゃいましたか",
+        "Where are you from? (polite)"
+      ],
+      [
+        "おしごとは？",
+        "おしごとは？",
+        "What do you do? (casual)"
+      ],
+      [
+        "がくせいですか",
+        "がくせいですか",
+        "Are you a student?"
+      ],
+      [
+        "そうです！",
+        "そうです！",
+        "That's right!"
+      ]
+    ],
+    "grammar": {
+      "pattern": "はじめまして。わたしは〜です。〜からきました。よろしくおねがいします",
+      "meaning": "Standard self-introduction",
+      "example_jp": "はじめまして。アランです。アメリカからきました。エンジニアをしています。よろしくおねがいします",
+      "example_en": "Nice to meet you. I'm Alan. I'm from America. I'm an engineer. Pleased to meet you"
+    },
+    "practice": "Write and practise a full 5-line self-introduction. Then write a dialogue between two people meeting for the first time.",
+    "tip": "You've now learned the most important sentence pattern in Japanese: XはYです. Everything builds on this foundation!"
+  },
+  {
+    "day": 57,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 9,
+    "title": "Subject Particle が",
+    "intro": "が marks the grammatical subject — often used to highlight NEW information or with certain verbs.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "だれが　きますか",
+        "だれが　きますか",
+        "Who is coming?"
+      ],
+      [
+        "なにが　すきですか",
+        "なにが　すきですか",
+        "What do you like?"
+      ],
+      [
+        "ねこが　います",
+        "ねこが　います",
+        "There is a cat"
+      ],
+      [
+        "あめが　ふっています",
+        "あめが　ふっています",
+        "It is raining"
+      ],
+      [
+        "わたしが　やります",
+        "わたしが　やります",
+        "I will do it (emphatic)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜が　あります/います",
+      "meaning": "There is ~ (exists)",
+      "example_jp": "つくえの　うえに　ほんが　あります",
+      "example_en": "There is a book on the desk"
+    },
+    "practice": "Make 3 sentences with が for emphasis ('I am the one who...') and 3 with あります/います.",
+    "tip": "は vs が: は = topic (already known), が = subject (new info / focus). This is one of the trickiest distinctions in Japanese!"
+  },
+  {
+    "day": 58,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 9,
+    "title": "Object Particle を",
+    "intro": "を marks the direct object — what receives the action of the verb.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "ほんを　よみます",
+        "ほんを　よみます",
+        "I read a book"
+      ],
+      [
+        "コーヒーを　のみます",
+        "コーヒーを　のみます",
+        "I drink coffee"
+      ],
+      [
+        "えいごを　べんきょうします",
+        "えいごを　べんきょうします",
+        "I study English"
+      ],
+      [
+        "おんがくを　ききます",
+        "おんがくを　ききます",
+        "I listen to music"
+      ],
+      [
+        "みちを　あるきます",
+        "みちを　あるきます",
+        "I walk along the road"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　Vます",
+      "meaning": "Do V to ~",
+      "example_jp": "まいあさ　にほんごを　べんきょうします",
+      "example_en": "I study Japanese every morning"
+    },
+    "practice": "Write 5 sentences about your daily habits using を + verb.",
+    "tip": "を is almost only used as the object particle — that makes it easy! When you see を, just know the word before it is being acted upon."
+  },
+  {
+    "day": 59,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 9,
+    "title": "Possessive Particle の",
+    "intro": "の connects nouns: X の Y = Y of X, or X's Y. Also used to nominalise verbs.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしの　ほん",
+        "わたしの　ほん",
+        "my book"
+      ],
+      [
+        "にほんの　たべもの",
+        "にほんの　たべもの",
+        "Japanese food"
+      ],
+      [
+        "かれの　なまえ",
+        "かれの　なまえ",
+        "his name"
+      ],
+      [
+        "がっこうの　せんせい",
+        "がっこうの　せんせい",
+        "school teacher"
+      ],
+      [
+        "どこの　くにですか",
+        "どこの　くにですか",
+        "What country are you from?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "X の Y",
+      "meaning": "Y of X / X's Y",
+      "example_jp": "これは　わたしの　にほんごの　じしょです",
+      "example_en": "This is my Japanese dictionary"
+    },
+    "practice": "Practice chaining の: 'my school's teacher', 'Japan's food', 'your friend's name'.",
+    "tip": "の can chain multiple nouns: 日本の大学の先生 (a teacher at a Japanese university). Just keep adding の!"
+  },
+  {
+    "day": 60,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 9,
+    "title": "Combining は・が・を・の",
+    "intro": "Practice combining the 4 particles learned so far in complex sentences.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしは　にほんごの　ほんを　よみます",
+        "わたしは　にほんごの　ほんを　よみます",
+        "I read a Japanese book"
+      ],
+      [
+        "あなたの　せんせいは　だれですか",
+        "あなたの　せんせいは　だれですか",
+        "Who is your teacher?"
+      ],
+      [
+        "わたしが　このほんを　かいました",
+        "わたしが　このほんを　かいました",
+        "I bought this book (emphatic)"
+      ],
+      [
+        "かれのくるまは　あかいです",
+        "かれのくるまは　あかいです",
+        "His car is red"
+      ],
+      [
+        "にほんのたべものが　すきです",
+        "にほんのたべものが　すきです",
+        "I like Japanese food"
+      ]
+    ],
+    "grammar": {
+      "pattern": "XはYのZをVます",
+      "meaning": "X does V to Z of Y",
+      "example_jp": "わたしは　にほんの　うたを　ききます",
+      "example_en": "I listen to Japanese songs"
+    },
+    "practice": "Write 3 complex sentences using 3+ particles each.",
+    "tip": "Particles are like labels on words. Once you understand each label's meaning, you can stack them to build any sentence!"
+  },
+  {
+    "day": 61,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 9,
+    "title": "Demonstratives: これ・それ・あれ",
+    "intro": "これ = this (near me), それ = that (near you), あれ = that (far from both).",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "これは　なんですか",
+        "これは　なんですか",
+        "What is this?"
+      ],
+      [
+        "それは　わたしの　かさです",
+        "それは　わたしの　かさです",
+        "That is my umbrella"
+      ],
+      [
+        "あれは　ふじさんです",
+        "あれは　ふじさんです",
+        "That (over there) is Mt. Fuji"
+      ],
+      [
+        "この　ほんは　おもしろいです",
+        "この　ほんは　おもしろいです",
+        "This book is interesting"
+      ],
+      [
+        "どれが　あなたのですか",
+        "どれが　あなたのですか",
+        "Which one is yours?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "これ/それ/あれ は 〜です",
+      "meaning": "This/That/That over there is ~",
+      "example_jp": "あれは　なんですか？　あれは　とうきょうタワーです",
+      "example_en": "What is that? That is Tokyo Tower"
+    },
+    "practice": "Point at 5 objects near and far and describe them using これ/それ/あれ.",
+    "tip": "これ/それ/あれ stand alone as pronouns. この/その/あの are used BEFORE a noun: このほん (this book), そのかばん (that bag)."
+  },
+  {
+    "day": 62,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 9,
+    "title": "Location Words",
+    "intro": "Spatial vocabulary: above, below, left, right, front, back, inside, outside.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "うえ",
+        "うえ",
+        "above / on top"
+      ],
+      [
+        "した",
+        "した",
+        "below / under"
+      ],
+      [
+        "みぎ",
+        "みぎ",
+        "right"
+      ],
+      [
+        "ひだり",
+        "ひだり",
+        "left"
+      ],
+      [
+        "まえ",
+        "まえ",
+        "front / before"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜の　うえに　あります",
+      "meaning": "It is on top of ~",
+      "example_jp": "つくえの　したに　ねこが　います",
+      "example_en": "There is a cat under the desk"
+    },
+    "practice": "Describe where 5 objects in your room are using location words + あります/います.",
+    "tip": "Location words always follow の: つくえのうえ (on the desk), いすのした (under the chair), ドアのまえ (in front of the door)."
+  },
+  {
+    "day": 63,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 9,
+    "title": "Particles Review & Reading",
+    "intro": "Review は、が、を、の plus demonstratives and location words. Read a short passage.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしのへやに　つくえが　あります",
+        "わたしのへやに　つくえが　あります",
+        "In my room there is a desk"
+      ],
+      [
+        "つくえのうえに　ほんと　ペンが　あります",
+        "つくえのうえに　ほんと　ペンが　あります",
+        "On the desk there are books and a pen"
+      ],
+      [
+        "まどのそとは　にわです",
+        "まどのそとは　にわです",
+        "Outside the window is a garden"
+      ],
+      [
+        "このほんは　おもしろいです",
+        "このほんは　おもしろいです",
+        "This book is interesting"
+      ],
+      [
+        "あなたのほんは　どこですか",
+        "あなたのほんは　どこですか",
+        "Where is your book?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜のそばに　〜があります",
+      "meaning": "Near ~, there is ~",
+      "example_jp": "えきのそばに　コンビニが　あります",
+      "example_en": "Near the station there is a convenience store"
+    },
+    "practice": "Write a 5-sentence paragraph describing your room or workspace using the particles learned.",
+    "tip": "Reading your own writing aloud is one of the best ways to internalise Japanese grammar patterns!"
+  },
+  {
+    "day": 64,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 10,
+    "title": "Location Particle に (existence)",
+    "intro": "に marks LOCATION of existence with あります/います.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "えきに　います",
+        "えきに　います",
+        "(I) am at the station"
+      ],
+      [
+        "つくえのうえに　あります",
+        "つくえのうえに　あります",
+        "It is on the desk"
+      ],
+      [
+        "にわに　ねこが　います",
+        "にわに　ねこが　います",
+        "There is a cat in the garden"
+      ],
+      [
+        "どこに　ありますか",
+        "どこに　ありますか",
+        "Where is it?"
+      ],
+      [
+        "がっこうに　せんせいが　います",
+        "がっこうに　せんせいが　います",
+        "There is a teacher at school"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　あります/います",
+      "meaning": "(thing) exists at/in ~",
+      "example_jp": "れいぞうこに　たまごが　あります",
+      "example_en": "There are eggs in the fridge"
+    },
+    "practice": "Practice: say where 5 objects are in your home or school using に + あります/います.",
+    "tip": "あります = for inanimate things. います = for living things (people, animals). Never mix them up!"
+  },
+  {
+    "day": 65,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 10,
+    "title": "Direction Particle に (movement)",
+    "intro": "に also marks the DESTINATION of movement: 〜に　いきます (go to ~).",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "がっこうに　いきます",
+        "がっこうに　いきます",
+        "I go to school"
+      ],
+      [
+        "えきに　きます",
+        "えきに　きます",
+        "I come to the station"
+      ],
+      [
+        "うちに　かえります",
+        "うちに　かえります",
+        "I return home"
+      ],
+      [
+        "にほんに　いきたい",
+        "にほんに　いきたい",
+        "I want to go to Japan"
+      ],
+      [
+        "どこに　いきますか",
+        "どこに　いきますか",
+        "Where are you going?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　いきます",
+      "meaning": "go to ~",
+      "example_jp": "あした　とうきょうに　いきます",
+      "example_en": "Tomorrow I will go to Tokyo"
+    },
+    "practice": "Make sentences about where you go: school, supermarket, hospital, Japan, etc.",
+    "tip": "に for destination vs で for location of action: がっこうに　いきます (go TO school) vs がっこうで　べんきょうします (study AT school)."
+  },
+  {
+    "day": 66,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 10,
+    "title": "Location of Action: で",
+    "intro": "で marks where an ACTION takes place (not just where something exists).",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "がっこうで　べんきょうします",
+        "がっこうで　べんきょうします",
+        "I study at school"
+      ],
+      [
+        "レストランで　たべます",
+        "レストランで　たべます",
+        "I eat at a restaurant"
+      ],
+      [
+        "こうえんで　あそびます",
+        "こうえんで　あそびます",
+        "I play in the park"
+      ],
+      [
+        "えきで　まちます",
+        "えきで　まちます",
+        "I wait at the station"
+      ],
+      [
+        "どこで　はたらいていますか",
+        "どこで　はたらいていますか",
+        "Where do you work?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜で　Vます",
+      "meaning": "do V at/in ~",
+      "example_jp": "としょかんで　ほんを　よみます",
+      "example_en": "I read books at the library"
+    },
+    "practice": "Describe your day using で: where you eat, study, work, exercise.",
+    "tip": "KEY DISTINCTION: に marks LOCATION of existence (ここにあります) while で marks LOCATION OF ACTION (ここでたべます). Many learners mix these up!"
+  },
+  {
+    "day": 67,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 10,
+    "title": "Means/Method: で",
+    "intro": "で also marks the MEANS by which something is done — transport, tools, language.",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "でんしゃで　いきます",
+        "でんしゃで　いきます",
+        "I go by train"
+      ],
+      [
+        "えいごで　はなします",
+        "えいごで　はなします",
+        "I speak in English"
+      ],
+      [
+        "はしで　たべます",
+        "はしで　たべます",
+        "I eat with chopsticks"
+      ],
+      [
+        "くるまで　きました",
+        "くるまで　きました",
+        "I came by car"
+      ],
+      [
+        "なにで　きましたか",
+        "なにで　きましたか",
+        "How did you come (by what means)?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜で　いきます",
+      "meaning": "go by ~ (transport)",
+      "example_jp": "じてんしゃで　がっこうに　いきます",
+      "example_en": "I go to school by bicycle"
+    },
+    "practice": "How do you get to school/work? Write 3 sentences using で + transport.",
+    "tip": "Same particle で, two uses: location of action AND means/method. Context makes it clear which meaning applies."
+  },
+  {
+    "day": 68,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 10,
+    "title": "Together with: と・や",
+    "intro": "と = and (exhaustive list / together with). や = and (partial list, etc.).",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "やまださんと　いきます",
+        "やまださんと　いきます",
+        "I go with Yamada-san"
+      ],
+      [
+        "ほんと　ペンが　あります",
+        "ほんと　ペンが　あります",
+        "There is a book and a pen"
+      ],
+      [
+        "すしや　てんぷらなど",
+        "すしや　てんぷらなど",
+        "sushi, tempura, etc."
+      ],
+      [
+        "ともだちと　あそびます",
+        "ともだちと　あそびます",
+        "I play/hang out with a friend"
+      ],
+      [
+        "なにと　なにが　すきですか",
+        "なにと　なにが　すきですか",
+        "What (things) do you like?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜と　〜が　あります",
+      "meaning": "There is ~ and ~",
+      "example_jp": "かばんの　なかに　さいふと　けいたいが　あります",
+      "example_en": "In my bag there is a wallet and a phone"
+    },
+    "practice": "List the things in your bag or room using と and や.",
+    "tip": "と = complete list (A and B, that's all). や = partial list (A and B and others). Use や when there are more items you aren't listing!"
+  },
+  {
+    "day": 69,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 10,
+    "title": "From/To: から・まで",
+    "intro": "から = from (place, time, reason). まで = until/to (place, time).",
+    "type": "particles",
+    "chars": [],
+    "vocab": [
+      [
+        "くじから　ごじまで",
+        "くじから　ごじまで",
+        "from 9 to 5"
+      ],
+      [
+        "えきから　あるきます",
+        "えきから　あるきます",
+        "I walk from the station"
+      ],
+      [
+        "とうきょうから　おおさかまで",
+        "とうきょうから　おおさかまで",
+        "from Tokyo to Osaka"
+      ],
+      [
+        "いつから　べんきょうしていますか",
+        "いつから　べんきょうしていますか",
+        "Since when have you been studying?"
+      ],
+      [
+        "〜だから",
+        "〜だから",
+        "because ~ (reason)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜から〜まで",
+      "meaning": "from ~ to/until ~",
+      "example_jp": "げつようびから　きんようびまで　はたらきます",
+      "example_en": "I work from Monday to Friday"
+    },
+    "practice": "Describe your schedule: from what time to what time do you study, work, sleep?",
+    "tip": "から also introduces reasons (だから = therefore, そうだから = because that's how it is). This links to grammar in Phase 6!"
+  },
+  {
+    "day": 70,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 10,
+    "title": "Particles Review",
+    "intro": "Full review of に、で、と、から、まで in combined sentences.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "でんしゃで　えきから　うちまで　かえります",
+        "でんしゃで　えきから　うちまで　かえります",
+        "I go home from the station to my house by train"
+      ],
+      [
+        "ともだちと　こうえんで　あそびます",
+        "ともだちと　こうえんで　あそびます",
+        "I play in the park with a friend"
+      ],
+      [
+        "かいしゃは　くじから　ごじまでです",
+        "かいしゃは　くじから　ごじまでです",
+        "Work is from 9 to 5"
+      ],
+      [
+        "にほんに　いきたいです",
+        "にほんに　いきたいです",
+        "I want to go to Japan"
+      ],
+      [
+        "どこで　ひるごはんを　たべますか",
+        "どこで　ひるごはんを　たべますか",
+        "Where do you eat lunch?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜で〜から〜まで〜に〜います",
+      "meaning": "Complex sentence with multiple particles",
+      "example_jp": "バスで　えきから　びょういんまで　いきます",
+      "example_en": "I go from the station to the hospital by bus"
+    },
+    "practice": "Write 5 complex sentences each using 3 or more particles.",
+    "tip": "You now know the core particles! は、が、を、の、に、で、と、も、から、まで — these cover 90% of everyday Japanese."
+  },
+  {
+    "day": 71,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 11,
+    "title": "い-Adjectives: Big, Small, New, Old",
+    "intro": "い-adjectives end in い and directly modify nouns. They also conjugate.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "おおきい　いえ",
+        "おおきい　いえ",
+        "big house"
+      ],
+      [
+        "ちいさい　ねこ",
+        "ちいさい　ねこ",
+        "small cat"
+      ],
+      [
+        "あたらしい　くるま",
+        "あたらしい　くるま",
+        "new car"
+      ],
+      [
+        "ふるい　ほん",
+        "ふるい　ほん",
+        "old book"
+      ],
+      [
+        "たかい　やま",
+        "たかい　やま",
+        "tall mountain / expensive"
+      ]
+    ],
+    "grammar": {
+      "pattern": "い-adj + noun",
+      "meaning": "adjective modifies noun directly",
+      "example_jp": "あたらしい　スマートフォンが　ほしいです",
+      "example_en": "I want a new smartphone"
+    },
+    "practice": "Describe 5 objects using い-adjectives: size, age, price, temperature.",
+    "tip": "い-adjectives are easy to use before nouns! Just put them directly in front: おおきい＋いえ = おおきいいえ. No の needed (unlike な-adjectives)."
+  },
+  {
+    "day": 72,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 11,
+    "title": "More い-Adjectives",
+    "intro": "Hot, cold, delicious, scary, fun — emotions and sensations.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "あついです",
+        "あついです",
+        "it is hot"
+      ],
+      [
+        "さむいです",
+        "さむいです",
+        "it is cold"
+      ],
+      [
+        "おいしいです",
+        "おいしいです",
+        "it is delicious"
+      ],
+      [
+        "こわいです",
+        "こわいです",
+        "it is scary"
+      ],
+      [
+        "たのしいです",
+        "たのしいです",
+        "it is fun"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　い-adjです",
+      "meaning": "~ is [adjective]",
+      "example_jp": "きょうは　あついですね！",
+      "example_en": "It's hot today, isn't it!"
+    },
+    "practice": "Describe today's weather, yesterday's dinner, and a recent activity using い-adjectives.",
+    "tip": "ね at the end seeks agreement (like 'isn't it?'). よ asserts a fact. This is just like Day 71 taught — these particles add tone!"
+  },
+  {
+    "day": 73,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 11,
+    "title": "い-Adj Conjugation: Negative & Past",
+    "intro": "い-adjectives conjugate! Negative: 〜くない。Past: 〜かった。Past negative: 〜くなかった。",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "あつくないです",
+        "あつくないです",
+        "it is not hot"
+      ],
+      [
+        "たかくないです",
+        "たかくないです",
+        "it is not expensive"
+      ],
+      [
+        "おもしろかったです",
+        "おもしろかったです",
+        "it was interesting"
+      ],
+      [
+        "さむくなかったです",
+        "さむくなかったです",
+        "it was not cold"
+      ],
+      [
+        "よかったです",
+        "よかったです",
+        "it was good (irregular: いい→よかった)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "い-adj → 〜くないです / 〜かったです",
+      "meaning": "not ~ / was ~",
+      "example_jp": "きのうは　そんなに　さむくなかったです",
+      "example_en": "Yesterday it wasn't that cold"
+    },
+    "practice": "Conjugate 5 adjectives in all 4 forms: present, negative, past, past negative.",
+    "tip": "Special case! いい (good) is irregular: past = よかった, not いかった. This is one of the most common adjectives — memorise it!"
+  },
+  {
+    "day": 74,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 11,
+    "title": "な-Adjectives",
+    "intro": "な-adjectives need な before nouns and だ/です in predicates. They DON'T conjugate with the adjective stem (the noun does the work).",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "しずかな　まち",
+        "しずかな　まち",
+        "quiet town"
+      ],
+      [
+        "きれいな　はな",
+        "きれいな　はな",
+        "pretty flower"
+      ],
+      [
+        "げんきな　こども",
+        "げんきな　こども",
+        "energetic child"
+      ],
+      [
+        "べんりな　アプリ",
+        "べんりな　アプリ",
+        "convenient app"
+      ],
+      [
+        "ゆうめいな　ひと",
+        "ゆうめいな　ひと",
+        "famous person"
+      ]
+    ],
+    "grammar": {
+      "pattern": "な-adj + な + noun / な-adj + です",
+      "meaning": "na-adjective modifying noun",
+      "example_jp": "にほんごは　たいせつな　げんごです",
+      "example_en": "Japanese is an important language"
+    },
+    "practice": "Practice: describe your town, a person you know, and your phone using な-adjectives.",
+    "tip": "な-adjectives look like nouns! In a sentence: しずかです (it is quiet). Before a noun: しずかな まち (quiet town). Don't forget the な!"
+  },
+  {
+    "day": 75,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 11,
+    "title": "Comparing: 〜より〜のほうが",
+    "intro": "AはBよりXです = A is more X than B. BよりAのほうがXです = A is more X than B (emphasising A).",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "とうきょうは　おおさかより　おおきいです",
+        "とうきょうは　おおさかより　おおきいです",
+        "Tokyo is bigger than Osaka"
+      ],
+      [
+        "でんしゃは　バスより　はやいです",
+        "でんしゃは　バスより　はやいです",
+        "Trains are faster than buses"
+      ],
+      [
+        "このほうが　すきです",
+        "このほうが　すきです",
+        "I prefer this one"
+      ],
+      [
+        "どちらが　すきですか",
+        "どちらが　すきですか",
+        "Which do you prefer?"
+      ],
+      [
+        "いちばん　すきです",
+        "いちばん　すきです",
+        "I like it the most"
+      ]
+    ],
+    "grammar": {
+      "pattern": "AはBより〜です",
+      "meaning": "A is more ~ than B",
+      "example_jp": "なつは　ふゆより　あついです",
+      "example_en": "Summer is hotter than winter"
+    },
+    "practice": "Make 5 comparisons: cities, seasons, foods, transport methods.",
+    "tip": "いちばん = the most (superlative). クラスで　いちばん　はやい (fastest in the class). Simple and powerful!"
+  },
+  {
+    "day": 76,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 11,
+    "title": "Adjective Review",
+    "intro": "Comprehensive review of い-adjectives and な-adjectives.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "おおきくて　あたらしいです",
+        "おおきくて　あたらしいです",
+        "big and new (i+i adj)"
+      ],
+      [
+        "しずかで　きれいです",
+        "しずかで　きれいです",
+        "quiet and beautiful (na+na adj)"
+      ],
+      [
+        "やすくて　おいしいです",
+        "やすくて　おいしいです",
+        "cheap and delicious"
+      ],
+      [
+        "ゆうめいで　べんりです",
+        "ゆうめいで　べんりです",
+        "famous and convenient"
+      ],
+      [
+        "あかくて　ちいさいです",
+        "あかくて　ちいさいです",
+        "red and small"
+      ]
+    ],
+    "grammar": {
+      "pattern": "adj1 + て/で + adj2",
+      "meaning": "adj1 and adj2 (linking adjectives)",
+      "example_jp": "このレストランは　やすくて　おいしいです",
+      "example_en": "This restaurant is cheap and delicious"
+    },
+    "practice": "Describe 5 things using 2 adjectives each, connected with て/で.",
+    "tip": "To connect い-adjectives: 〜くて。To connect な-adjectives: 〜で。Mixed: first adj follows its own rule, second adj ends normally."
+  },
+  {
+    "day": 77,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 11,
+    "title": "Adjective Review & Short Descriptions",
+    "intro": "Writing short descriptions using all adjectives and particles learned.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "わたしのまちは　しずかで　きれいです",
+        "わたしのまちは　しずかで　きれいです",
+        "My town is quiet and beautiful"
+      ],
+      [
+        "にほんごは　むずかしいですが　おもしろいです",
+        "にほんごは　むずかしいですが　おもしろいです",
+        "Japanese is difficult but interesting"
+      ],
+      [
+        "あのひとは　せがたかくて　かっこいいです",
+        "あのひとは　せがたかくて　かっこいいです",
+        "That person is tall and good-looking"
+      ],
+      [
+        "このまちは　にぎやかで　べんりです",
+        "このまちは　にぎやかで　べんりです",
+        "This town is lively and convenient"
+      ],
+      [
+        "おすしは　おいしいですが　たかいです",
+        "おすしは　おいしいですが　たかいです",
+        "Sushi is delicious but expensive"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は〜ですが、〜です",
+      "meaning": "~ is ~, but ~",
+      "example_jp": "にほんごは　むずかしいですが、たのしいです",
+      "example_en": "Japanese is difficult, but it's fun"
+    },
+    "practice": "Write a description of: your home, your city, your favourite food — using at least 2 adjectives each.",
+    "tip": "が after a clause means 'but' — contrasting two ideas. わかりますが、むずかしいです (I understand it, but it's difficult)."
+  },
+  {
+    "day": 78,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 12,
+    "title": "Verbs: ます Form Introduction",
+    "intro": "Japanese verbs end in ます in polite form. Two main groups: る-verbs and う-verbs.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "たべます",
+        "たべます",
+        "eat (polite)"
+      ],
+      [
+        "のみます",
+        "のみます",
+        "drink (polite)"
+      ],
+      [
+        "いきます",
+        "いきます",
+        "go (polite)"
+      ],
+      [
+        "きます",
+        "きます",
+        "come (polite)"
+      ],
+      [
+        "します",
+        "します",
+        "do (polite)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ます",
+      "meaning": "polite present/future verb",
+      "example_jp": "まいにち　にほんごを　べんきょうします",
+      "example_en": "I study Japanese every day"
+    },
+    "practice": "Memorise these 10 core verbs in ます form: たべます、のみます、いきます、きます、します、みます、ききます、よみます、かきます、はなします.",
+    "tip": "ます form is the standard polite level for daily conversation. Think of it as the 'default' form you'll use with anyone you don't know well."
+  },
+  {
+    "day": 79,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 12,
+    "title": "Common Verbs in ます Form",
+    "intro": "Expanding the verb vocabulary with essential daily verbs.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "おきます",
+        "おきます",
+        "get up / wake up"
+      ],
+      [
+        "ねます",
+        "ねます",
+        "sleep / go to bed"
+      ],
+      [
+        "たちます",
+        "たちます",
+        "stand up"
+      ],
+      [
+        "すわります",
+        "すわります",
+        "sit down"
+      ],
+      [
+        "あるきます",
+        "あるきます",
+        "walk"
+      ]
+    ],
+    "grammar": {
+      "pattern": "なんじに　〜ますか",
+      "meaning": "At what time do you ~?",
+      "example_jp": "なんじに　おきますか？　ろくじに　おきます",
+      "example_en": "What time do you wake up? I wake up at 6"
+    },
+    "practice": "Describe your morning routine using 5 different verbs in ます form.",
+    "tip": "に after a time word marks the specific time: ろくじに おきます (wake up AT 6). Without に: まいあさ おきます (wake up every morning — no specific time)."
+  },
+  {
+    "day": 80,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 12,
+    "title": "Negative: 〜ません",
+    "intro": "〜ません is the polite negative. Add it instead of 〜ます.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "たべません",
+        "たべません",
+        "don't eat"
+      ],
+      [
+        "いきません",
+        "いきません",
+        "don't go"
+      ],
+      [
+        "わかりません",
+        "わかりません",
+        "don't understand"
+      ],
+      [
+        "にほんごを　はなしません",
+        "にほんごを　はなしません",
+        "don't speak Japanese"
+      ],
+      [
+        "テレビを　みません",
+        "テレビを　みません",
+        "don't watch TV"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ません",
+      "meaning": "don't / won't ~ (polite negative)",
+      "example_jp": "わたしは　お酒を　のみません",
+      "example_en": "I don't drink alcohol"
+    },
+    "practice": "Negate 5 sentences from yesterday's practice. Then write 3 things you don't do.",
+    "tip": "Don't confuse ません (negative present) with ませんでした (negative past). The でした marks it as past tense!"
+  },
+  {
+    "day": 81,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 12,
+    "title": "Past: 〜ました",
+    "intro": "〜ました is the polite past tense. Negative past: 〜ませんでした.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "たべました",
+        "たべました",
+        "ate"
+      ],
+      [
+        "いきました",
+        "いきました",
+        "went"
+      ],
+      [
+        "べんきょうしました",
+        "べんきょうしました",
+        "studied"
+      ],
+      [
+        "みませんでした",
+        "みませんでした",
+        "didn't watch"
+      ],
+      [
+        "はなしました",
+        "はなしました",
+        "spoke"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ました / 〜ませんでした",
+      "meaning": "did ~ / didn't ~",
+      "example_jp": "きのう　えいがを　みました",
+      "example_en": "Yesterday I watched a movie"
+    },
+    "practice": "Describe yesterday: 3 things you did (〜ました) and 2 you didn't do (〜ませんでした).",
+    "tip": "The key: ます→ました (did), ません→ませんでした (didn't). The pattern is perfectly regular!"
+  },
+  {
+    "day": 82,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 12,
+    "title": "Verb Patterns with Frequency",
+    "intro": "Frequency adverbs: まいにち (every day), よく (often), ときどき (sometimes), あまり〜ない (not much).",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "まいにち　べんきょうします",
+        "まいにち　べんきょうします",
+        "study every day"
+      ],
+      [
+        "よく　えいがを　みます",
+        "よく　えいがを　みます",
+        "often watch movies"
+      ],
+      [
+        "ときどき　そとで　たべます",
+        "ときどき　そとで　たべます",
+        "sometimes eat out"
+      ],
+      [
+        "あまり　テレビを　みません",
+        "あまり　テレビを　みません",
+        "don't watch TV much"
+      ],
+      [
+        "ぜんぜん　たべません",
+        "ぜんぜん　たべません",
+        "don't eat at all"
+      ]
+    ],
+    "grammar": {
+      "pattern": "あまり〜ません",
+      "meaning": "don't ~ very much",
+      "example_jp": "あまり　にくを　たべません",
+      "example_en": "I don't eat much meat"
+    },
+    "practice": "Write about your habits using frequency words: まいにち、よく、ときどき、あまり〜ない、ぜんぜん〜ない.",
+    "tip": "あまり and ぜんぜん ALWAYS go with negative verbs (ません). Never: あまり　たべます. Correct: あまり　たべません."
+  },
+  {
+    "day": 83,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 12,
+    "title": "Core Verb Vocabulary List",
+    "intro": "Vocabulary building: 20 essential verbs for N5.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "みる",
+        "みる",
+        "see / watch"
+      ],
+      [
+        "きく",
+        "きく",
+        "listen / ask"
+      ],
+      [
+        "よむ",
+        "よむ",
+        "read"
+      ],
+      [
+        "かく",
+        "かく",
+        "write"
+      ],
+      [
+        "かう",
+        "かう",
+        "buy"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　Vます",
+      "meaning": "do V to ~",
+      "example_jp": "まいにち　にほんごを　べんきょうして、おんがくを　きいて、ほんを　よみます",
+      "example_en": "Every day I study Japanese, listen to music, and read books"
+    },
+    "practice": "Make sentences with: みます、かいます、かきます、はなします、おしえます、おぼえます、わすれます、つかいます.",
+    "tip": "Tip: みる、きく、よむ、かく、はなす are the 5 communication verbs. If you can do these in Japanese, you can learn anything!"
+  },
+  {
+    "day": 84,
+    "phaseNum": 3,
+    "phaseName": "Foundations",
+    "week": 12,
+    "title": "Foundations Full Review",
+    "intro": "Review all of Phase 3 with JLPT-style practice questions.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "なんじに　がっこうに　いきますか",
+        "なんじに　がっこうに　いきますか",
+        "What time do you go to school?"
+      ],
+      [
+        "きのう　なにを　しましたか",
+        "きのう　なにを　しましたか",
+        "What did you do yesterday?"
+      ],
+      [
+        "このまちは　どんなまちですか",
+        "このまちは　どんなまちですか",
+        "What kind of town is this?"
+      ],
+      [
+        "〜は　どこに　ありますか",
+        "〜は　どこに　ありますか",
+        "Where is ~?"
+      ],
+      [
+        "なんようびが　すきですか",
+        "なんようびが　すきですか",
+        "What day of the week do you like?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　どんな〜ですか",
+      "meaning": "What kind of ~ is ~?",
+      "example_jp": "にほんは　どんなくにですか",
+      "example_en": "What kind of country is Japan?"
+    },
+    "practice": "Answer all 5 questions above in complete Japanese sentences. Then review any areas you found difficult.",
+    "tip": "Congratulations on completing Phase 3! You now have the foundation to hold basic conversations in Japanese. Phase 4 builds vocabulary!"
+  },
+  {
+    "day": 85,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 13,
+    "title": "Family: My Own Family (Humble)",
+    "intro": "In Japanese, you use humble words for YOUR family and respectful words for others' families. Today: your own.",
+    "type": "lesson",
+    "chars": [
+      [
+        "ちち",
+        "my father"
+      ],
+      [
+        "はは",
+        "my mother"
+      ],
+      [
+        "あに",
+        "my older brother"
+      ],
+      [
+        "あね",
+        "my older sister"
+      ],
+      [
+        "おとうと",
+        "my younger brother"
+      ]
+    ],
+    "vocab": [
+      [
+        "いもうと",
+        "いもうと",
+        "my younger sister"
+      ],
+      [
+        "かぞく",
+        "かぞく",
+        "family"
+      ],
+      [
+        "りょうしん",
+        "りょうしん",
+        "both parents"
+      ],
+      [
+        "きょうだい",
+        "きょうだい",
+        "siblings"
+      ],
+      [
+        "かぞくは　なんにんですか",
+        "かぞくは　なんにんですか",
+        "How many people are in your family?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "かぞくは　〜にんです",
+      "meaning": "My family has ~ people",
+      "example_jp": "かぞくは　よにんです。ちちとはははとあにとわたしです",
+      "example_en": "My family has 4 people: father, mother, older brother, and me"
+    },
+    "practice": "Describe your family in Japanese: how many people, who they are, what they do.",
+    "tip": "For YOUR family: ちち、はは、あに、あね (humble). For OTHERS' families: おとうさん、おかあさん、おにいさん、おねえさん (respectful). Never mix them up!"
+  },
+  {
+    "day": 86,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 13,
+    "title": "Family: Others' Families (Respectful)",
+    "intro": "When talking about someone else's family, use honorific forms.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "おとうさん",
+        "おとうさん",
+        "someone's father"
+      ],
+      [
+        "おかあさん",
+        "おかあさん",
+        "someone's mother"
+      ],
+      [
+        "おにいさん",
+        "おにいさん",
+        "someone's older brother"
+      ],
+      [
+        "おねえさん",
+        "おねえさん",
+        "someone's older sister"
+      ],
+      [
+        "おこさん",
+        "おこさん",
+        "someone's child"
+      ],
+      [
+        "ごかぞく",
+        "ごかぞく",
+        "your/their family"
+      ],
+      [
+        "ごきょうだい",
+        "ごきょうだい",
+        "your/their siblings"
+      ],
+      [
+        "おばあさん",
+        "おばあさん",
+        "someone's grandmother"
+      ],
+      [
+        "おじいさん",
+        "おじいさん",
+        "someone's grandfather"
+      ],
+      [
+        "ごりょうしん",
+        "ごりょうしん",
+        "your parents"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: おとうさんは　おげんきですか (Is your father well?) Example: ごかぞくは　なんにんですか (How many people are in your family?)",
+    "tip": "Practice the humble/respectful distinction: describe YOUR family, then ask about SOMEONE ELSE's family."
+  },
+  {
+    "day": 87,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 13,
+    "title": "Extended Family",
+    "intro": "Grandparents, aunts, uncles, cousins — the full family tree.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "そふ",
+        "そふ",
+        "my grandfather"
+      ],
+      [
+        "そぼ",
+        "そぼ",
+        "my grandmother"
+      ],
+      [
+        "おじ",
+        "おじ",
+        "my uncle"
+      ],
+      [
+        "おば",
+        "おば",
+        "my aunt"
+      ],
+      [
+        "いとこ",
+        "いとこ",
+        "cousin"
+      ],
+      [
+        "おじいさん",
+        "おじいさん",
+        "someone's grandfather"
+      ],
+      [
+        "おばあさん",
+        "おばあさん",
+        "someone's grandmother"
+      ],
+      [
+        "まご",
+        "まご",
+        "grandchild"
+      ],
+      [
+        "おい",
+        "おい",
+        "nephew"
+      ],
+      [
+        "めい",
+        "めい",
+        "niece"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜の　〜です (~ 's ~) Example: これは　そぼの　しゃしんです (This is a photo of my grandmother)",
+    "tip": "Draw a family tree and label each person with their Japanese name (humble forms for your family)."
+  },
+  {
+    "day": 88,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 13,
+    "title": "Family Conversations",
+    "intro": "Putting family vocabulary into natural dialogue.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "かぞくの　しゃしんを　みせてください",
+        "かぞくの　しゃしんを　みせてください",
+        "Please show me a photo of your family"
+      ],
+      [
+        "なんにんきょうだいですか",
+        "なんにんきょうだいですか",
+        "How many siblings do you have?"
+      ],
+      [
+        "ひとりっこです",
+        "ひとりっこです",
+        "I'm an only child"
+      ],
+      [
+        "〜さいです",
+        "〜さいです",
+        "(person) is ~ years old"
+      ],
+      [
+        "かかがにほんじんです",
+        "かかがにほんじんです",
+        "My mother is Japanese"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: なんにんきょうだいですか (How many siblings do you have?) Example: ふたりきょうだいです。あにがひとりいます (I have one sibling — an older brother)",
+    "tip": "Write a paragraph about your family: size, ages, occupations, and any interesting details."
+  },
+  {
+    "day": 89,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 13,
+    "title": "People Words",
+    "intro": "Words for describing and talking about people.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "ひと",
+        "ひと",
+        "person"
+      ],
+      [
+        "おとこのひと",
+        "おとこのひと",
+        "man"
+      ],
+      [
+        "おんなのひと",
+        "おんなのひと",
+        "woman"
+      ],
+      [
+        "こども",
+        "こども",
+        "child"
+      ],
+      [
+        "おとな",
+        "おとな",
+        "adult"
+      ],
+      [
+        "わかもの",
+        "わかもの",
+        "young person"
+      ],
+      [
+        "おじさん",
+        "おじさん",
+        "middle-aged man / uncle"
+      ],
+      [
+        "おばさん",
+        "おばさん",
+        "middle-aged woman / aunt"
+      ],
+      [
+        "あかちゃん",
+        "あかちゃん",
+        "baby"
+      ],
+      [
+        "ともだち",
+        "ともだち",
+        "friend"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: どんなひとですか (What kind of person is ~?) Example: かれは　やさしくて　おもしろいひとです (He is a kind and interesting person)",
+    "tip": "Describe 3 people you know using adjectives + ひとです."
+  },
+  {
+    "day": 90,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 13,
+    "title": "Relationships",
+    "intro": "Words for different types of relationships.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "ともだち",
+        "ともだち",
+        "friend"
+      ],
+      [
+        "しりあい",
+        "しりあい",
+        "acquaintance"
+      ],
+      [
+        "クラスメート",
+        "クラスメート",
+        "classmate"
+      ],
+      [
+        "どうりょう",
+        "どうりょう",
+        "colleague"
+      ],
+      [
+        "じょうし",
+        "じょうし",
+        "boss"
+      ],
+      [
+        "せんぱい",
+        "せんぱい",
+        "senior (at school/work)"
+      ],
+      [
+        "こうはい",
+        "こうはい",
+        "junior (at school/work)"
+      ],
+      [
+        "かれし",
+        "かれし",
+        "boyfriend"
+      ],
+      [
+        "かのじょ",
+        "かのじょ",
+        "girlfriend / she"
+      ],
+      [
+        "けっこんしています",
+        "けっこんしています",
+        "married"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜は　わたしの　〜です (~ is my ~) Example: たなかさんは　わたしの　どうりょうです (Tanaka-san is my colleague)",
+    "tip": "Introduce 3 people in your life using relationship words."
+  },
+  {
+    "day": 91,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 13,
+    "title": "Family Review",
+    "intro": "Consolidate all family vocabulary with a writing and speaking exercise.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "かぞくしょうかい",
+        "かぞくしょうかい",
+        "family introduction"
+      ],
+      [
+        "ちちは　かいしゃいんです",
+        "ちちは　かいしゃいんです",
+        "My father is an office worker"
+      ],
+      [
+        "はははりょうりが　じょうずです",
+        "はははりょうりが　じょうずです",
+        "My mother is good at cooking"
+      ],
+      [
+        "あにはだいがくせいです",
+        "あにはだいがくせいです",
+        "My older brother is a university student"
+      ],
+      [
+        "かぞくがだいすきです",
+        "かぞくがだいすきです",
+        "I love my family"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜は〜で、〜が　じょうずです (~ is a ~ and is good at ~) Example: ははは　せんせいで、えいごが　じょうずです (My mother is a teacher and is good at English)",
+    "tip": "Write a 5-sentence paragraph introducing your family to a Japanese friend."
+  },
+  {
+    "day": 92,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "Head & Face",
+    "intro": "Body part vocabulary — essential for healthcare and descriptions.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "あたま",
+        "あたま",
+        "head"
+      ],
+      [
+        "かお",
+        "かお",
+        "face"
+      ],
+      [
+        "め",
+        "め",
+        "eye/eyes"
+      ],
+      [
+        "はな",
+        "はな",
+        "nose"
+      ],
+      [
+        "くち",
+        "くち",
+        "mouth"
+      ],
+      [
+        "みみ",
+        "みみ",
+        "ear/ears"
+      ],
+      [
+        "は",
+        "は",
+        "tooth/teeth"
+      ],
+      [
+        "くびれ",
+        "くち",
+        "neck"
+      ],
+      [
+        "まゆげ",
+        "まゆげ",
+        "eyebrow"
+      ],
+      [
+        "まつげ",
+        "まつげ",
+        "eyelash"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜が　いたいです (~ hurts / I have a ~ ache) Example: あたまが　いたいです (I have a headache)",
+    "tip": "Point to and say each body part. Practice: 'My _ hurts' for 5 body parts."
+  },
+  {
+    "day": 93,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "Arms & Hands",
+    "intro": "Upper body parts for descriptions and medical conversations.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "かた",
+        "かた",
+        "shoulder"
+      ],
+      [
+        "うで",
+        "うで",
+        "arm"
+      ],
+      [
+        "ひじ",
+        "ひじ",
+        "elbow"
+      ],
+      [
+        "て",
+        "て",
+        "hand"
+      ],
+      [
+        "ゆび",
+        "ゆび",
+        "finger"
+      ],
+      [
+        "てくび",
+        "てくび",
+        "wrist"
+      ],
+      [
+        "つめ",
+        "つめ",
+        "nail/claw"
+      ],
+      [
+        "こぶし",
+        "こぶし",
+        "fist"
+      ],
+      [
+        "てのひら",
+        "てのひら",
+        "palm"
+      ],
+      [
+        "おやゆび",
+        "おやゆび",
+        "thumb"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜をVてください (Please do V with your ~) Example: てを　あげてください (Please raise your hand)",
+    "tip": "Practice giving instructions using body parts: raise your hand, open your mouth, etc."
+  },
+  {
+    "day": 94,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "Legs & Lower Body",
+    "intro": "Lower body vocabulary.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "むね",
+        "むね",
+        "chest"
+      ],
+      [
+        "おなか",
+        "おなか",
+        "stomach/belly"
+      ],
+      [
+        "せなか",
+        "せなか",
+        "back"
+      ],
+      [
+        "こし",
+        "こし",
+        "lower back/hip"
+      ],
+      [
+        "あし",
+        "あし",
+        "leg/foot"
+      ],
+      [
+        "ひざ",
+        "ひざ",
+        "knee"
+      ],
+      [
+        "くるぶし",
+        "くるぶし",
+        "ankle"
+      ],
+      [
+        "かかと",
+        "かかと",
+        "heel"
+      ],
+      [
+        "つまさき",
+        "つまさき",
+        "toes/tip of foot"
+      ],
+      [
+        "そく",
+        "そく",
+        "foot (counter: 〜そく for footwear)"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜のちょうしは　どうですか (How is your ~ doing?) Example: おなかの　ちょうしは　どうですか (How is your stomach?)",
+    "tip": "Describe any aches or pains you have using body part + がいたいです."
+  },
+  {
+    "day": 95,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "Body + Adjectives",
+    "intro": "Describing physical appearance using body parts and adjectives.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "せがたかい",
+        "せがたかい",
+        "tall (height)"
+      ],
+      [
+        "せがひくい",
+        "せがひくい",
+        "short (height)"
+      ],
+      [
+        "かみがながい",
+        "かみがながい",
+        "long hair"
+      ],
+      [
+        "めがおおきい",
+        "めがおおきい",
+        "big eyes"
+      ],
+      [
+        "がっしりした",
+        "がっしりした",
+        "stocky/sturdy build"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜が〜です ((person's) ~ is ~) Example: かのじょは　かみが　ながくて　めが　おおきいです (She has long hair and big eyes)",
+    "tip": "Describe yourself or someone you know: height, hair, eyes, build."
+  },
+  {
+    "day": 96,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "At the Doctor",
+    "intro": "Medical vocabulary for describing symptoms and seeing a doctor.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "びょうき",
+        "びょうき",
+        "illness"
+      ],
+      [
+        "くすり",
+        "くすり",
+        "medicine"
+      ],
+      [
+        "びょういん",
+        "びょういん",
+        "hospital"
+      ],
+      [
+        "いしゃ",
+        "いしゃ",
+        "doctor"
+      ],
+      [
+        "かんごし",
+        "かんごし",
+        "nurse"
+      ],
+      [
+        "しんさつ",
+        "しんさつ",
+        "medical examination"
+      ],
+      [
+        "ちゅうしゃ",
+        "ちゅうしゃ",
+        "injection"
+      ],
+      [
+        "けっさ",
+        "けっさ",
+        "blood test"
+      ],
+      [
+        "レントゲン",
+        "レントゲン",
+        "X-ray"
+      ],
+      [
+        "しょほうせん",
+        "しょほうせん",
+        "prescription"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜が　いたいです / 〜が　かゆいです (~ hurts / ~ is itchy) Example: せんせい、のどが　いたくて、ねつが　あります (Doctor, my throat hurts and I have a fever)",
+    "tip": "Practice a doctor's visit dialogue: describe your symptoms and ask for medicine."
+  },
+  {
+    "day": 97,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "Health & Illness",
+    "intro": "Common illness and health vocabulary.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "かぜ",
+        "かぜ",
+        "cold (illness)"
+      ],
+      [
+        "ねつ",
+        "ねつ",
+        "fever"
+      ],
+      [
+        "せき",
+        "せき",
+        "cough"
+      ],
+      [
+        "はなみず",
+        "はなみず",
+        "runny nose"
+      ],
+      [
+        "ずつう",
+        "ずつう",
+        "headache"
+      ],
+      [
+        "きぶんがわるい",
+        "きぶんがわるい",
+        "feel sick/unwell"
+      ],
+      [
+        "つかれた",
+        "つかれた",
+        "tired/exhausted"
+      ],
+      [
+        "ねむい",
+        "ねむい",
+        "sleepy"
+      ],
+      [
+        "げんき",
+        "げんき",
+        "healthy/energetic"
+      ],
+      [
+        "かいふく",
+        "かいふく",
+        "recovery"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: 〜の　ちょうしが　わるいです (My ~ is not in good shape) Example: きのうから　かぜの　ちょうしです (I've had a cold since yesterday)",
+    "tip": "Write about the last time you were sick: what happened, what symptoms did you have?"
+  },
+  {
+    "day": 98,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "Body Review",
+    "intro": "Review all body vocabulary with a description exercise.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "あたま",
+        "あたま",
+        "head"
+      ],
+      [
+        "かお",
+        "かお",
+        "face"
+      ],
+      [
+        "て",
+        "て",
+        "hand"
+      ],
+      [
+        "あし",
+        "あし",
+        "leg/foot"
+      ],
+      [
+        "からだ",
+        "からだ",
+        "body"
+      ]
+    ],
+    "grammar": {},
+    "practice": "Pattern: からだに　きをつけてください (Please take care of your body/health) Example: まいにち　うんどうして、からだに　きをつけています (I exercise every day and take care of my health)",
+    "tip": "Describe a person's appearance (head to toe) in 5-6 sentences."
+  },
+  {
+    "day": 99,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 14,
+    "title": "Colors: Basic",
+    "intro": "あか=red, あお=blue, きいろ=yellow. Essential colors for daily life.",
+    "type": "lesson",
+    "chars": [
+      [
+        "あか",
+        "red"
+      ],
+      [
+        "あお",
+        "blue"
+      ],
+      [
+        "きいろ",
+        "yellow"
+      ],
+      [
+        "しろ",
+        "white"
+      ],
+      [
+        "くろ",
+        "black"
+      ]
+    ],
+    "vocab": [
+      [
+        "みどり",
+        "みどり",
+        "green"
+      ],
+      [
+        "ちゃいろ",
+        "ちゃいろ",
+        "brown"
+      ],
+      [
+        "オレンジ",
+        "オレンジ",
+        "orange"
+      ],
+      [
+        "ピンク",
+        "ピンク",
+        "pink"
+      ],
+      [
+        "むらさき",
+        "むらさき",
+        "purple"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　なにいろですか",
+      "meaning": "What color is ~?",
+      "example_jp": "そのバッグは　なにいろですか。くろです",
+      "example_en": "What color is that bag? It's black"
+    },
+    "practice": "Ask what color 5 objects are and answer in Japanese.",
+    "tip": "あかい/あおい/きいろい/しろい/くろい are い-adjectives. But みどり、loanwords use noun+の: みどりの　くるま (green car)."
+  },
+  {
+    "day": 100,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 15,
+    "title": "Colors in Sentences",
+    "intro": "Describing things by color in natural sentences.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "あかい　りんご",
+        "あかい　りんご",
+        "red apple"
+      ],
+      [
+        "あおい　そら",
+        "あおい　そら",
+        "blue sky"
+      ],
+      [
+        "きいろい　はな",
+        "きいろい　はな",
+        "yellow flower"
+      ],
+      [
+        "くろい　くるま",
+        "くろい　くるま",
+        "black car"
+      ],
+      [
+        "しろい　ゆき",
+        "しろい　ゆき",
+        "white snow"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜いろの〜",
+      "meaning": "a ~ colored ~",
+      "example_jp": "みどりいろの　ドレスが　すきです",
+      "example_en": "I like a green dress"
+    },
+    "practice": "Describe 5 things in your environment using color adjectives.",
+    "tip": "Japanese traffic lights: the 'go' light is called あお (blue) even though it looks green! Historical linguistic usage."
+  },
+  {
+    "day": 101,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 15,
+    "title": "Shapes & Sizes",
+    "intro": "Basic shapes and size vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "まる",
+        "circle"
+      ],
+      [
+        "しかく",
+        "square"
+      ],
+      [
+        "さんかく",
+        "triangle"
+      ],
+      [
+        "ながしかく",
+        "rectangle"
+      ],
+      [
+        "ほし",
+        "star"
+      ]
+    ],
+    "vocab": [
+      [
+        "おおきい",
+        "おおきい",
+        "big"
+      ],
+      [
+        "ちいさい",
+        "ちいさい",
+        "small"
+      ],
+      [
+        "まるい",
+        "まるい",
+        "round"
+      ],
+      [
+        "ほそい",
+        "ほそい",
+        "thin"
+      ],
+      [
+        "ふとい",
+        "ふとい",
+        "thick/fat"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜い　かたちです",
+      "meaning": "It is a ~ shape",
+      "example_jp": "このつくえは　ながしかくです",
+      "example_en": "This desk is rectangular"
+    },
+    "practice": "Describe the shape and size of 5 objects around you.",
+    "tip": "まるい (round) is an い-adjective. まる (circle) is a noun. Both are useful in different contexts!"
+  },
+  {
+    "day": 102,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 15,
+    "title": "Food: Basic",
+    "intro": "Core food vocabulary for dining and cooking.",
+    "type": "lesson",
+    "chars": [
+      [
+        "ごはん",
+        "rice/meal"
+      ],
+      [
+        "パン",
+        "bread"
+      ],
+      [
+        "にく",
+        "meat"
+      ],
+      [
+        "さかな",
+        "fish"
+      ],
+      [
+        "やさい",
+        "vegetables"
+      ]
+    ],
+    "vocab": [
+      [
+        "くだもの",
+        "くだもの",
+        "fruit"
+      ],
+      [
+        "たまご",
+        "たまご",
+        "egg"
+      ],
+      [
+        "チーズ",
+        "チーズ",
+        "cheese"
+      ],
+      [
+        "とりにく",
+        "とりにく",
+        "chicken"
+      ],
+      [
+        "ぶたにく",
+        "ぶたにく",
+        "pork"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜が　すきです",
+      "meaning": "I like ~",
+      "example_jp": "やさいが　すきですが、にくは　あまり　すきじゃないです",
+      "example_en": "I like vegetables but don't really like meat"
+    },
+    "practice": "Write about your food preferences: 3 things you like and 2 you don't.",
+    "tip": "ごはん means both 'cooked rice' AND 'meal': あさごはん=breakfast, ひるごはん=lunch, ばんごはん=dinner."
+  },
+  {
+    "day": 103,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 15,
+    "title": "Japanese Cuisine",
+    "intro": "Traditional Japanese dishes — essential for dining in Japan.",
+    "type": "lesson",
+    "chars": [
+      [
+        "すし",
+        "sushi"
+      ],
+      [
+        "ラーメン",
+        "ramen"
+      ],
+      [
+        "てんぷら",
+        "tempura"
+      ],
+      [
+        "うどん",
+        "udon"
+      ],
+      [
+        "そば",
+        "soba"
+      ]
+    ],
+    "vocab": [
+      [
+        "おにぎり",
+        "おにぎり",
+        "rice ball"
+      ],
+      [
+        "みそしる",
+        "みそしる",
+        "miso soup"
+      ],
+      [
+        "やきとり",
+        "やきとり",
+        "grilled chicken"
+      ],
+      [
+        "たこやき",
+        "たこやき",
+        "octopus balls"
+      ],
+      [
+        "おこのみやき",
+        "おこのみやき",
+        "savory pancake"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　ください",
+      "meaning": "Please give me ~",
+      "example_jp": "ラーメンを　ひとつと　ぎょうざを　ふたつ　ください",
+      "example_en": "One ramen and two gyoza please"
+    },
+    "practice": "Memorise 5 Japanese dishes and practice ordering them.",
+    "tip": "Japan has incredible regional food specialties. ラーメン has regional styles, たこやき is from Osaka. Food is a great cultural entry point!"
+  },
+  {
+    "day": 104,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 15,
+    "title": "Drinks",
+    "intro": "Beverage vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "みず",
+        "water"
+      ],
+      [
+        "おちゃ",
+        "green tea"
+      ],
+      [
+        "コーヒー",
+        "coffee"
+      ],
+      [
+        "ジュース",
+        "juice"
+      ],
+      [
+        "ビール",
+        "beer"
+      ]
+    ],
+    "vocab": [
+      [
+        "ぎゅうにゅう",
+        "ぎゅうにゅう",
+        "milk"
+      ],
+      [
+        "コーラ",
+        "コーラ",
+        "cola"
+      ],
+      [
+        "おさけ",
+        "おさけ",
+        "alcohol"
+      ],
+      [
+        "ワイン",
+        "ワイン",
+        "wine"
+      ],
+      [
+        "ウーロンちゃ",
+        "ウーロンちゃ",
+        "oolong tea"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　いっぱい　ください",
+      "meaning": "One cup/glass of ~ please",
+      "example_jp": "アイスコーヒーを　ひとつ　ください",
+      "example_en": "One iced coffee please"
+    },
+    "practice": "Practice ordering drinks at a cafe.",
+    "tip": "お茶 in Japan = green tea. For black tea say こうちゃ. Convenience stores have an amazing variety of tea!"
+  },
+  {
+    "day": 105,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 15,
+    "title": "Food Adjectives",
+    "intro": "Describing food and handling restaurant situations.",
+    "type": "lesson",
+    "chars": [
+      [
+        "おいしい",
+        "delicious"
+      ],
+      [
+        "まずい",
+        "bad-tasting"
+      ],
+      [
+        "あまい",
+        "sweet"
+      ],
+      [
+        "からい",
+        "spicy"
+      ],
+      [
+        "しょっぱい",
+        "salty"
+      ]
+    ],
+    "vocab": [
+      [
+        "すっぱい",
+        "すっぱい",
+        "sour"
+      ],
+      [
+        "にがい",
+        "にがい",
+        "bitter"
+      ],
+      [
+        "あっさり",
+        "あっさり",
+        "light flavour"
+      ],
+      [
+        "こってり",
+        "こってり",
+        "rich/heavy"
+      ],
+      [
+        "おすすめ",
+        "おすすめ",
+        "recommendation"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　どんな　あじですか",
+      "meaning": "What does ~ taste like?",
+      "example_jp": "このカレーは　からくて　おいしいです",
+      "example_en": "This curry is spicy and delicious"
+    },
+    "practice": "Describe your favourite meal using food adjectives.",
+    "tip": "おいしい！ is the #1 compliment in Japan. Say it enthusiastically — it will make any Japanese cook happy!"
+  },
+  {
+    "day": 106,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 16,
+    "title": "Places: Town",
+    "intro": "Places you visit in daily life.",
+    "type": "lesson",
+    "chars": [
+      [
+        "えき",
+        "station"
+      ],
+      [
+        "スーパー",
+        "supermarket"
+      ],
+      [
+        "コンビニ",
+        "convenience store"
+      ],
+      [
+        "びょういん",
+        "hospital"
+      ],
+      [
+        "ゆうびんきょく",
+        "post office"
+      ]
+    ],
+    "vocab": [
+      [
+        "ぎんこう",
+        "ぎんこう",
+        "bank"
+      ],
+      [
+        "としょかん",
+        "としょかん",
+        "library"
+      ],
+      [
+        "デパート",
+        "デパート",
+        "department store"
+      ],
+      [
+        "くうこう",
+        "くうこう",
+        "airport"
+      ],
+      [
+        "バスてい",
+        "バスてい",
+        "bus stop"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　いきます",
+      "meaning": "I go to ~",
+      "example_jp": "まいあさ　コンビニに　よって　コーヒーを　かいます",
+      "example_en": "Every morning I stop by the convenience store and buy coffee"
+    },
+    "practice": "Write where you go each day of the week.",
+    "tip": "コンビニ is a Japanese institution! Open 24/7, they sell food, pay bills, print documents, and much more."
+  },
+  {
+    "day": 107,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 16,
+    "title": "Places: School & Work",
+    "intro": "Educational and workplace vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "がっこう",
+        "school"
+      ],
+      [
+        "だいがく",
+        "university"
+      ],
+      [
+        "かいしゃ",
+        "company"
+      ],
+      [
+        "じむしょ",
+        "office"
+      ],
+      [
+        "きょうしつ",
+        "classroom"
+      ]
+    ],
+    "vocab": [
+      [
+        "としょしつ",
+        "としょしつ",
+        "school library"
+      ],
+      [
+        "たいいくかん",
+        "たいいくかん",
+        "gymnasium"
+      ],
+      [
+        "しょくどう",
+        "しょくどう",
+        "cafeteria"
+      ],
+      [
+        "かいぎしつ",
+        "かいぎしつ",
+        "meeting room"
+      ],
+      [
+        "うけつけ",
+        "うけつけ",
+        "reception"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜で　はたらいています",
+      "meaning": "I work at ~",
+      "example_jp": "わたしは　ちいさな　かいしゃで　はたらいています",
+      "example_en": "I work at a small company"
+    },
+    "practice": "Describe your school or workplace.",
+    "tip": "日本語学校 (にほんごがっこう) = Japanese language school. Many foreigners study at these in Japan!"
+  },
+  {
+    "day": 108,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 16,
+    "title": "Nature & Outdoors",
+    "intro": "Outdoor locations.",
+    "type": "lesson",
+    "chars": [
+      [
+        "こうえん",
+        "park"
+      ],
+      [
+        "やま",
+        "mountain"
+      ],
+      [
+        "かわ",
+        "river"
+      ],
+      [
+        "うみ",
+        "sea"
+      ],
+      [
+        "もり",
+        "forest"
+      ]
+    ],
+    "vocab": [
+      [
+        "のはら",
+        "のはら",
+        "field"
+      ],
+      [
+        "たき",
+        "たき",
+        "waterfall"
+      ],
+      [
+        "しま",
+        "しま",
+        "island"
+      ],
+      [
+        "みずうみ",
+        "みずうみ",
+        "lake"
+      ],
+      [
+        "そら",
+        "そら",
+        "sky"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　いってみたいです",
+      "meaning": "I'd like to try going to ~",
+      "example_jp": "いつか　ふじさんに　のぼってみたいです",
+      "example_en": "Someday I'd like to try climbing Mt. Fuji"
+    },
+    "practice": "Write about a natural place you'd like to visit in Japan.",
+    "tip": "Japan's must-see nature: ふじさん, 日光 (にっこう), 白川郷 (しらかわごう). Which would you visit first?"
+  },
+  {
+    "day": 109,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 16,
+    "title": "Directions",
+    "intro": "How to give and understand directions.",
+    "type": "lesson",
+    "chars": [
+      [
+        "まっすぐ",
+        "straight ahead"
+      ],
+      [
+        "みぎ",
+        "right"
+      ],
+      [
+        "ひだり",
+        "left"
+      ],
+      [
+        "まがる",
+        "turn"
+      ],
+      [
+        "とまる",
+        "stop"
+      ]
+    ],
+    "vocab": [
+      [
+        "しんごう",
+        "しんごう",
+        "traffic light"
+      ],
+      [
+        "かど",
+        "かど",
+        "corner"
+      ],
+      [
+        "〜をすぎて",
+        "〜をすぎて",
+        "past ~"
+      ],
+      [
+        "ちかくです",
+        "ちかくです",
+        "it's nearby"
+      ],
+      [
+        "とおいです",
+        "とおいです",
+        "it's far"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜をみぎに　まがってください",
+      "meaning": "Please turn right at ~",
+      "example_jp": "つぎのしんごうを　ひだりに　まがって、まっすぐいくと　えきがあります",
+      "example_en": "Turn left at the next light, go straight, and you'll find the station"
+    },
+    "practice": "Practice giving directions from your home to the nearest station.",
+    "tip": "Useful phrase: すみません、〜はどこですか. In Japan, showing a map on your phone is also very effective!"
+  },
+  {
+    "day": 110,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 16,
+    "title": "Weather",
+    "intro": "Weather expressions for daily small talk.",
+    "type": "lesson",
+    "chars": [
+      [
+        "はれ",
+        "sunny"
+      ],
+      [
+        "くもり",
+        "cloudy"
+      ],
+      [
+        "あめ",
+        "rain"
+      ],
+      [
+        "ゆき",
+        "snow"
+      ],
+      [
+        "かぜ",
+        "wind"
+      ]
+    ],
+    "vocab": [
+      [
+        "きり",
+        "きり",
+        "fog"
+      ],
+      [
+        "かみなり",
+        "かみなり",
+        "thunder"
+      ],
+      [
+        "たいふう",
+        "たいふう",
+        "typhoon"
+      ],
+      [
+        "てんきよほう",
+        "てんきよほう",
+        "weather forecast"
+      ],
+      [
+        "きおん",
+        "きおん",
+        "temperature"
+      ]
+    ],
+    "grammar": {
+      "pattern": "きょうの　てんきは〜です",
+      "meaning": "Today's weather is ~",
+      "example_jp": "あしたは　あめの　ちです。かさを　もっていって！",
+      "example_en": "It will probably rain tomorrow. Take an umbrella!"
+    },
+    "practice": "Describe today's weather and your weekly forecast.",
+    "tip": "Japan has 4 distinct seasons AND a rainy season (つゆ/梅雨, June-July). Weather small talk is extremely common!"
+  },
+  {
+    "day": 111,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 16,
+    "title": "Seasons",
+    "intro": "The four seasons and seasonal vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "はる",
+        "spring"
+      ],
+      [
+        "なつ",
+        "summer"
+      ],
+      [
+        "あき",
+        "autumn"
+      ],
+      [
+        "ふゆ",
+        "winter"
+      ],
+      [
+        "きせつ",
+        "season"
+      ]
+    ],
+    "vocab": [
+      [
+        "あたたかい",
+        "あたたかい",
+        "warm"
+      ],
+      [
+        "あつい",
+        "あつい",
+        "hot"
+      ],
+      [
+        "すずしい",
+        "すずしい",
+        "cool"
+      ],
+      [
+        "さむい",
+        "さむい",
+        "cold"
+      ],
+      [
+        "さくら",
+        "さくら",
+        "cherry blossom"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　〜が　いちばん　すきです",
+      "meaning": "I like ~ the most in ~",
+      "example_jp": "わたしは　あきが　いちばん　すきです。すずしくて　きれいです",
+      "example_en": "I like autumn the most. It's cool and beautiful"
+    },
+    "practice": "Which season do you like best and why? Write 3-4 sentences.",
+    "tip": "Cherry blossom (さくら) season and autumn foliage (こうよう) are Japan's most celebrated seasonal events!"
+  },
+  {
+    "day": 112,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 17,
+    "title": "Animals: Common",
+    "intro": "Common animals.",
+    "type": "lesson",
+    "chars": [
+      [
+        "いぬ",
+        "dog"
+      ],
+      [
+        "ねこ",
+        "cat"
+      ],
+      [
+        "とり",
+        "bird"
+      ],
+      [
+        "さかな",
+        "fish"
+      ],
+      [
+        "うま",
+        "horse"
+      ]
+    ],
+    "vocab": [
+      [
+        "うし",
+        "うし",
+        "cow"
+      ],
+      [
+        "ぶた",
+        "ぶた",
+        "pig"
+      ],
+      [
+        "うさぎ",
+        "うさぎ",
+        "rabbit"
+      ],
+      [
+        "くま",
+        "くま",
+        "bear"
+      ],
+      [
+        "さる",
+        "さる",
+        "monkey"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　かっています",
+      "meaning": "I keep ~ as a pet",
+      "example_jp": "いえで　ねこを　にひき　かっています",
+      "example_en": "I keep two cats at home"
+    },
+    "practice": "Do you have pets? Describe them using body and personality adjectives.",
+    "tip": "Japanese animal sounds: dog=ワンワン, cat=ニャーニャー, frog=ゲロゲロ. Very different from English!"
+  },
+  {
+    "day": 113,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 17,
+    "title": "Animals: Wild & More",
+    "intro": "Wild and exotic animals.",
+    "type": "lesson",
+    "chars": [
+      [
+        "ぞう",
+        "elephant"
+      ],
+      [
+        "らいおん",
+        "lion"
+      ],
+      [
+        "きりん",
+        "giraffe"
+      ],
+      [
+        "とら",
+        "tiger"
+      ],
+      [
+        "しろくま",
+        "polar bear"
+      ]
+    ],
+    "vocab": [
+      [
+        "たぬき",
+        "たぬき",
+        "raccoon dog"
+      ],
+      [
+        "きつね",
+        "きつね",
+        "fox"
+      ],
+      [
+        "しか",
+        "しか",
+        "deer"
+      ],
+      [
+        "へび",
+        "へび",
+        "snake"
+      ],
+      [
+        "さかな",
+        "さかな",
+        "fish"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　〜より　おおきいです",
+      "meaning": "~ is bigger than ~",
+      "example_jp": "ぞうは　きりんより　おもいです",
+      "example_en": "Elephants are heavier than giraffes"
+    },
+    "practice": "Compare 3 pairs of animals using より.",
+    "tip": "たぬき (tanuki/raccoon dog) appears everywhere in Japanese folklore — look for ceramic statues outside shops for good luck!"
+  },
+  {
+    "day": 114,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 17,
+    "title": "Nature & Sky",
+    "intro": "Natural world vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "そら",
+        "sky"
+      ],
+      [
+        "つき",
+        "moon"
+      ],
+      [
+        "ほし",
+        "star"
+      ],
+      [
+        "たいよう",
+        "sun"
+      ],
+      [
+        "くも",
+        "cloud"
+      ]
+    ],
+    "vocab": [
+      [
+        "はな",
+        "はな",
+        "flower"
+      ],
+      [
+        "き",
+        "き",
+        "tree"
+      ],
+      [
+        "くさ",
+        "くさ",
+        "grass"
+      ],
+      [
+        "いし",
+        "いし",
+        "stone"
+      ],
+      [
+        "つち",
+        "つち",
+        "earth/soil"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜がきれいですね",
+      "meaning": "~ is beautiful, isn't it",
+      "example_jp": "こんばん　ほしが　きれいですね",
+      "example_en": "The stars are beautiful tonight, aren't they"
+    },
+    "practice": "Describe your favourite natural scenery in Japanese.",
+    "tip": "Japanese has poetic nature words like 木漏れ日 (こもれび) = sunlight filtering through leaves. Nature has deep cultural significance in Japan!"
+  },
+  {
+    "day": 115,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 17,
+    "title": "Hobbies & Free Time",
+    "intro": "Common hobby vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "しゅみ",
+        "hobby"
+      ],
+      [
+        "スポーツ",
+        "sports"
+      ],
+      [
+        "おんがく",
+        "music"
+      ],
+      [
+        "えいが",
+        "movie"
+      ],
+      [
+        "りょこう",
+        "travel"
+      ]
+    ],
+    "vocab": [
+      [
+        "どくしょ",
+        "どくしょ",
+        "reading"
+      ],
+      [
+        "りょうり",
+        "りょうり",
+        "cooking"
+      ],
+      [
+        "ゲーム",
+        "ゲーム",
+        "gaming"
+      ],
+      [
+        "えをかく",
+        "えをかく",
+        "drawing"
+      ],
+      [
+        "うたう",
+        "うたう",
+        "singing"
+      ]
+    ],
+    "grammar": {
+      "pattern": "しゅみは　〜です",
+      "meaning": "My hobby is ~",
+      "example_jp": "しゅみは　りょこうと　にほんごの　べんきょうです",
+      "example_en": "My hobbies are travel and studying Japanese"
+    },
+    "practice": "Introduce your hobbies. Ask someone else about their hobbies.",
+    "tip": "〜がすきです (I like ~) focuses on preference; 〜をしています (I do ~) focuses on activity. Both natural for hobbies!"
+  },
+  {
+    "day": 116,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 17,
+    "title": "Daily Routine",
+    "intro": "Verbs and times for a typical day.",
+    "type": "lesson",
+    "chars": [
+      [
+        "おきる",
+        "wake up"
+      ],
+      [
+        "シャワーをあびる",
+        "shower"
+      ],
+      [
+        "あさごはん",
+        "breakfast"
+      ],
+      [
+        "がっこうにいく",
+        "go to school"
+      ],
+      [
+        "かえる",
+        "return home"
+      ]
+    ],
+    "vocab": [
+      [
+        "ばんごはん",
+        "ばんごはん",
+        "dinner"
+      ],
+      [
+        "ふろにはいる",
+        "ふろにはいる",
+        "take a bath"
+      ],
+      [
+        "テレビをみる",
+        "テレビをみる",
+        "watch TV"
+      ],
+      [
+        "ねる",
+        "ねる",
+        "sleep"
+      ],
+      [
+        "はをみがく",
+        "はをみがく",
+        "brush teeth"
+      ]
+    ],
+    "grammar": {
+      "pattern": "まいにち　〜ます",
+      "meaning": "I ~ every day",
+      "example_jp": "まいあさ　ろくじに　おきて、シャワーをあびて、あさごはんを　たべます",
+      "example_en": "Every morning I wake up at 6, shower, and eat breakfast"
+    },
+    "practice": "Write your complete daily routine from morning to night.",
+    "tip": "Japanese routines often chain actions with the て-form: おきて、シャワーをあびて、ごはんをたべて... (Phase 5 covers this!)"
+  },
+  {
+    "day": 117,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 18,
+    "title": "School Vocabulary",
+    "intro": "School-related vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "じゅぎょう",
+        "class"
+      ],
+      [
+        "せんせい",
+        "teacher"
+      ],
+      [
+        "がくせい",
+        "student"
+      ],
+      [
+        "しゅくだい",
+        "homework"
+      ],
+      [
+        "テスト",
+        "test"
+      ]
+    ],
+    "vocab": [
+      [
+        "やすみじかん",
+        "やすみじかん",
+        "break time"
+      ],
+      [
+        "たいいく",
+        "たいいく",
+        "P.E."
+      ],
+      [
+        "りか",
+        "りか",
+        "science"
+      ],
+      [
+        "すうがく",
+        "すうがく",
+        "math"
+      ],
+      [
+        "えいご",
+        "えいご",
+        "English"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　べんきょうしています",
+      "meaning": "I am studying ~",
+      "example_jp": "いま　にほんごを　べんきょうしています",
+      "example_en": "I am currently studying Japanese"
+    },
+    "practice": "Write about your favourite school subject and why.",
+    "tip": "Japanese school subjects: こくご (Japanese lit.), えいご (English), すうがく (math), りか (science), しゃかい (social studies), おんがく (music), びじゅつ (art)."
+  },
+  {
+    "day": 118,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 18,
+    "title": "Work & Career",
+    "intro": "Work-related vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "しごと",
+        "work"
+      ],
+      [
+        "かいしゃ",
+        "company"
+      ],
+      [
+        "かいぎ",
+        "meeting"
+      ],
+      [
+        "しゃいん",
+        "employee"
+      ],
+      [
+        "きゅうりょう",
+        "salary"
+      ]
+    ],
+    "vocab": [
+      [
+        "きゅうか",
+        "きゅうか",
+        "paid leave"
+      ],
+      [
+        "ざんぎょう",
+        "ざんぎょう",
+        "overtime"
+      ],
+      [
+        "しゅっちょう",
+        "しゅっちょう",
+        "business trip"
+      ],
+      [
+        "めいし",
+        "めいし",
+        "business card"
+      ],
+      [
+        "ぶちょう",
+        "ぶちょう",
+        "department head"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜で　はたらいています",
+      "meaning": "I work at ~",
+      "example_jp": "IT かいしゃで　エンジニアとして　はたらいています",
+      "example_en": "I work as an engineer at an IT company"
+    },
+    "practice": "Describe your current or ideal job in Japanese.",
+    "tip": "Business cards (めいし) are exchanged with both hands and a bow in Japan — treat them with great respect!"
+  },
+  {
+    "day": 119,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 18,
+    "title": "Shopping",
+    "intro": "Shopping vocabulary and phrases.",
+    "type": "lesson",
+    "chars": [
+      [
+        "みせ",
+        "shop"
+      ],
+      [
+        "ねだん",
+        "price"
+      ],
+      [
+        "わりびき",
+        "discount"
+      ],
+      [
+        "うりきれ",
+        "sold out"
+      ],
+      [
+        "レジ",
+        "cash register"
+      ]
+    ],
+    "vocab": [
+      [
+        "いくらですか",
+        "いくらですか",
+        "How much?"
+      ],
+      [
+        "〜をみせてください",
+        "〜をみせてください",
+        "Please show me ~"
+      ],
+      [
+        "おつり",
+        "おつり",
+        "change (money)"
+      ],
+      [
+        "ふくろ",
+        "ふくろ",
+        "bag"
+      ],
+      [
+        "クレジットカード",
+        "クレジットカード",
+        "credit card"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　〜つ　ください",
+      "meaning": "Please give me ~ of ~",
+      "example_jp": "このTシャツのMサイズをください",
+      "example_en": "Please give me a medium-size of this T-shirt"
+    },
+    "practice": "Practice a shopping dialogue: ask the price, buy an item, receive change.",
+    "tip": "In Japan: ふくろはいりますか (Do you need a bag?) — plastic bags cost extra. Say だいじょうぶです to decline politely!"
+  },
+  {
+    "day": 120,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 18,
+    "title": "い-Adjective Review",
+    "intro": "Comprehensive review of all い-adjectives learned.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "おおきい/ちいさい",
+        "おおきい/ちいさい",
+        "big/small"
+      ],
+      [
+        "たかい/やすい",
+        "たかい/やすい",
+        "expensive/cheap"
+      ],
+      [
+        "あたらしい/ふるい",
+        "あたらしい/ふるい",
+        "new/old"
+      ],
+      [
+        "おいしい/まずい",
+        "おいしい/まずい",
+        "delicious/bad"
+      ],
+      [
+        "たのしい/つまらない",
+        "たのしい/つまらない",
+        "fun/boring"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜くて、〜いです",
+      "meaning": "~ and ~ (chaining)",
+      "example_jp": "このレストランは　やすくて　おいしくて　にぎやかです",
+      "example_en": "This restaurant is cheap, delicious, and lively"
+    },
+    "practice": "Write 5 sentences using 2 chained い-adjectives.",
+    "tip": "KEY: い-adjectives conjugate. Present: 〜い、Neg: 〜くない、Past: 〜かった、Past neg: 〜くなかった. いい→よかった (irregular!)"
+  },
+  {
+    "day": 121,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 18,
+    "title": "な-Adjective Review",
+    "intro": "Comprehensive review of な-adjectives.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "しずかな/にぎやかな",
+        "しずかな/にぎやかな",
+        "quiet/lively"
+      ],
+      [
+        "きれいな/きたない",
+        "きれいな/きたない",
+        "beautiful/dirty"
+      ],
+      [
+        "べんりな/ふべんな",
+        "べんりな/ふべんな",
+        "convenient/inconvenient"
+      ],
+      [
+        "げんきな/びょうきな",
+        "げんきな/びょうきな",
+        "healthy/sick"
+      ],
+      [
+        "すきな/きらいな",
+        "すきな/きらいな",
+        "liked/disliked"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜で、〜です (na-adj chain)",
+      "meaning": "~ and ~",
+      "example_jp": "このまちは　しずかで　きれいで　べんりです",
+      "example_en": "This town is quiet, beautiful, and convenient"
+    },
+    "practice": "Describe your ideal town/home using な-adjectives.",
+    "tip": "な-adjective chaining uses で (not て). Mixed chains: やすくて　きれいです (cheap and beautiful — い then な)."
+  },
+  {
+    "day": 122,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 19,
+    "title": "Likes & Dislikes",
+    "intro": "Expressing preferences and abilities.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "〜がすきです",
+        "〜がすきです",
+        "I like ~"
+      ],
+      [
+        "〜がきらいです",
+        "〜がきらいです",
+        "I dislike ~"
+      ],
+      [
+        "〜がとくいです",
+        "〜がとくいです",
+        "I'm good at ~"
+      ],
+      [
+        "〜がにがてです",
+        "〜がにがてです",
+        "I'm bad at ~"
+      ],
+      [
+        "〜がほしいです",
+        "〜がほしいです",
+        "I want ~ (thing)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜がいちばんすきです",
+      "meaning": "I like ~ the most",
+      "example_jp": "たべものの　なかで　ラーメンが　いちばん　すきです",
+      "example_en": "Among foods, I like ramen the most"
+    },
+    "practice": "Write your top 3 likes and dislikes in food, hobbies, and subjects.",
+    "tip": "Note: すき and きらい take が, not を! 'I like sushi' = すしが すきです (NOT すしを すきです)."
+  },
+  {
+    "day": 123,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 19,
+    "title": "Core Verbs Review",
+    "intro": "Review of all verbs introduced so far.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "たべる・のむ",
+        "たべる・のむ",
+        "eat/drink"
+      ],
+      [
+        "いく・くる・かえる",
+        "いく・くる・かえる",
+        "go/come/return"
+      ],
+      [
+        "みる・きく・よむ",
+        "みる・きく・よむ",
+        "see/listen/read"
+      ],
+      [
+        "かく・はなす・かう",
+        "かく・はなす・かう",
+        "write/speak/buy"
+      ],
+      [
+        "おきる・ねる・やすむ",
+        "おきる・ねる・やすむ",
+        "wake/sleep/rest"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜て、〜て、〜ます (chaining)",
+      "meaning": "Do ~, do ~, and do ~",
+      "example_jp": "まいあさ　おきて、べんきょうして、しごとに　いきます",
+      "example_en": "Every morning I wake up, study, and go to work"
+    },
+    "practice": "Write your daily routine using 5 different verbs.",
+    "tip": "Keep a verb notebook! Organize by type: RU-verbs (drop る, add ます) and U-verbs (stem changes). We'll master these in Phase 5!"
+  },
+  {
+    "day": 124,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 19,
+    "title": "Adverbs of Degree",
+    "intro": "Adverbs that modify adjectives: とても、すこし、あまり.",
+    "type": "lesson",
+    "chars": [
+      [
+        "とても",
+        "very"
+      ],
+      [
+        "すこし",
+        "a little"
+      ],
+      [
+        "かなり",
+        "quite"
+      ],
+      [
+        "すごく",
+        "very (casual)"
+      ],
+      [
+        "ちょっと",
+        "a little (casual)"
+      ]
+    ],
+    "vocab": [
+      [
+        "あまり〜ない",
+        "あまり〜ない",
+        "not very ~"
+      ],
+      [
+        "ぜんぜん〜ない",
+        "ぜんぜん〜ない",
+        "not at all ~"
+      ],
+      [
+        "もっと",
+        "もっと",
+        "more"
+      ],
+      [
+        "たくさん",
+        "たくさん",
+        "a lot"
+      ],
+      [
+        "ほとんど〜ない",
+        "ほとんど〜ない",
+        "hardly ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "とても/すごく　〜です",
+      "meaning": "very ~",
+      "example_jp": "きょうは　すごく　あついですね！",
+      "example_en": "It's very hot today, isn't it!"
+    },
+    "practice": "Add degree adverbs to 5 sentences to make them sound more natural.",
+    "tip": "あまり and ぜんぜん ALWAYS go with negative verbs (ません). Never: あまりたべます. Correct: あまりたべません."
+  },
+  {
+    "day": 125,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 19,
+    "title": "Question Words Review",
+    "intro": "All question words (疑問詞) in one place.",
+    "type": "lesson",
+    "chars": [
+      [
+        "なに/なん",
+        "what"
+      ],
+      [
+        "だれ",
+        "who"
+      ],
+      [
+        "いつ",
+        "when"
+      ],
+      [
+        "どこ",
+        "where"
+      ],
+      [
+        "なぜ/どうして",
+        "why"
+      ]
+    ],
+    "vocab": [
+      [
+        "どう",
+        "どう",
+        "how (manner)"
+      ],
+      [
+        "どんな",
+        "どんな",
+        "what kind of"
+      ],
+      [
+        "どのくらい",
+        "どのくらい",
+        "how much/long"
+      ],
+      [
+        "いくつ",
+        "いくつ",
+        "how many"
+      ],
+      [
+        "いくら",
+        "いくら",
+        "how much (price)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　どこですか / いつですか / なんですか",
+      "meaning": "Where/When/What is ~?",
+      "example_jp": "つぎの　でんしゃは　なんじですか",
+      "example_en": "What time is the next train?"
+    },
+    "practice": "Create 5 different questions using different question words.",
+    "tip": "Question words go where the answer would go: だれがきますか (Who is coming?) — だれ replaces the person's name. Logical!"
+  },
+  {
+    "day": 126,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 19,
+    "title": "Vocabulary Midpoint Review",
+    "intro": "Review days 85-125 — all vocabulary learned in Phase 4 so far.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "かぞく",
+        "かぞく",
+        "family"
+      ],
+      [
+        "からだ",
+        "からだ",
+        "body"
+      ],
+      [
+        "たべもの",
+        "たべもの",
+        "food"
+      ],
+      [
+        "ばしょ",
+        "ばしょ",
+        "place"
+      ],
+      [
+        "てんき",
+        "てんき",
+        "weather"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜について　はなしてください",
+      "meaning": "Please talk about ~",
+      "example_jp": "あなたの　かぞくに　ついて　はなしてください",
+      "example_en": "Please tell me about your family"
+    },
+    "practice": "Answer in Japanese: What did you eat today? Where do you live? What are your hobbies? Who is your best friend?",
+    "tip": "Half of Phase 4 complete! The key to retention: use words in sentences, not just memorise lists. Make a vocab journal!"
+  },
+  {
+    "day": 127,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 19,
+    "title": "い-Adj: Emotions & Feelings",
+    "intro": "Emotion and feeling adjectives.",
+    "type": "lesson",
+    "chars": [
+      [
+        "うれしい",
+        "happy/glad"
+      ],
+      [
+        "かなしい",
+        "sad"
+      ],
+      [
+        "こわい",
+        "scary"
+      ],
+      [
+        "たのしい",
+        "fun"
+      ],
+      [
+        "つらい",
+        "painful/tough"
+      ]
+    ],
+    "vocab": [
+      [
+        "はずかしい",
+        "はずかしい",
+        "embarrassed"
+      ],
+      [
+        "さびしい",
+        "さびしい",
+        "lonely"
+      ],
+      [
+        "ねむい",
+        "ねむい",
+        "sleepy"
+      ],
+      [
+        "いたい",
+        "いたい",
+        "painful"
+      ],
+      [
+        "びっくりした",
+        "びっくりした",
+        "surprised"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜くて　たまりません",
+      "meaning": "I can't stand how ~",
+      "example_jp": "さびしくて　たまりません",
+      "example_en": "I can't stand the loneliness"
+    },
+    "practice": "Express your current feelings in Japanese. Write 3 emotion sentences.",
+    "tip": "Japanese often expresses emotions indirectly. Sometimes 〜です alone isn't enough — adding ね or よ adds emotional nuance!"
+  },
+  {
+    "day": 128,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 20,
+    "title": "Personality Adjectives",
+    "intro": "Describing personality traits.",
+    "type": "lesson",
+    "chars": [
+      [
+        "やさしい",
+        "kind/gentle"
+      ],
+      [
+        "おもしろい",
+        "interesting/funny"
+      ],
+      [
+        "まじめ(な)",
+        "serious/diligent"
+      ],
+      [
+        "あかるい",
+        "bright/cheerful"
+      ],
+      [
+        "おとなしい",
+        "quiet/gentle"
+      ]
+    ],
+    "vocab": [
+      [
+        "しんせつ(な)",
+        "しんせつ(な)",
+        "kind/helpful"
+      ],
+      [
+        "ゆうき(な)",
+        "ゆうき(な)",
+        "courageous"
+      ],
+      [
+        "のんき(な)",
+        "のんき(な)",
+        "easygoing"
+      ],
+      [
+        "なまけもの",
+        "なまけもの",
+        "lazy person"
+      ],
+      [
+        "がんばりや",
+        "がんばりや",
+        "hardworking person"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　〜な　ひとです",
+      "meaning": "~ is a ~ person",
+      "example_jp": "かれは　やさしくて　まじめな　ひとです",
+      "example_en": "He is a kind and serious person"
+    },
+    "practice": "Describe your personality and the personality of someone you admire.",
+    "tip": "Personality adjectives mix い and な types: やさしい (い-adj), まじめ (な-adj). Watch out for the different usage rules!"
+  },
+  {
+    "day": 129,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 20,
+    "title": "Size & Quantity",
+    "intro": "Expressing size, amount and quantity.",
+    "type": "lesson",
+    "chars": [
+      [
+        "おおい",
+        "many/a lot (quantity)"
+      ],
+      [
+        "すくない",
+        "few/little"
+      ],
+      [
+        "おおきい",
+        "big (size)"
+      ],
+      [
+        "ちいさい",
+        "small (size)"
+      ],
+      [
+        "ひろい",
+        "wide/spacious"
+      ]
+    ],
+    "vocab": [
+      [
+        "せまい",
+        "せまい",
+        "narrow/cramped"
+      ],
+      [
+        "ふかい",
+        "ふかい",
+        "deep"
+      ],
+      [
+        "あさい",
+        "あさい",
+        "shallow"
+      ],
+      [
+        "おもい",
+        "おもい",
+        "heavy"
+      ],
+      [
+        "かるい",
+        "かるい",
+        "light (weight)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜が　おおいです/すくないです",
+      "meaning": "There are many/few ~",
+      "example_jp": "このまちは　ひとが　おおくて　にぎやかです",
+      "example_en": "This town has many people and is lively"
+    },
+    "practice": "Describe your room or city using quantity and size adjectives.",
+    "tip": "Note: おおい (many) and すくない (few) are い-adjectives about QUANTITY. おおきい (big) is about SIZE. Don't confuse them!"
+  },
+  {
+    "day": 130,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 20,
+    "title": "Speed & Distance",
+    "intro": "Speed, distance, and movement vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "はやい",
+        "fast/early"
+      ],
+      [
+        "おそい",
+        "slow/late"
+      ],
+      [
+        "とおい",
+        "far"
+      ],
+      [
+        "ちかい",
+        "near/close"
+      ],
+      [
+        "まっすぐ",
+        "straight"
+      ]
+    ],
+    "vocab": [
+      [
+        "すぐに",
+        "すぐに",
+        "immediately/soon"
+      ],
+      [
+        "ゆっくり",
+        "ゆっくり",
+        "slowly"
+      ],
+      [
+        "だいたい",
+        "だいたい",
+        "approximately"
+      ],
+      [
+        "〜キロ",
+        "〜キロ",
+        "~ kilometres"
+      ],
+      [
+        "〜ふん(かかる)",
+        "〜ふん(かかる)",
+        "takes ~ minutes"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜から　〜まで　〜ぷんかかります",
+      "meaning": "It takes ~ minutes from ~ to ~",
+      "example_jp": "えきから　うちまで　あるいて　じゅっぷんかかります",
+      "example_en": "It takes 10 minutes to walk from the station to my house"
+    },
+    "practice": "Describe distances: how far is the station, supermarket, school from your home?",
+    "tip": "かかります (it takes) is used for time and money. じかんがかかります (it takes time), おかねがかかります (it costs money)."
+  },
+  {
+    "day": 131,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 20,
+    "title": "Transport",
+    "intro": "Transportation vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "でんしゃ",
+        "train"
+      ],
+      [
+        "バス",
+        "bus"
+      ],
+      [
+        "じてんしゃ",
+        "bicycle"
+      ],
+      [
+        "くるま",
+        "car"
+      ],
+      [
+        "ひこうき",
+        "airplane"
+      ]
+    ],
+    "vocab": [
+      [
+        "タクシー",
+        "タクシー",
+        "taxi"
+      ],
+      [
+        "ちかてつ",
+        "ちかてつ",
+        "subway"
+      ],
+      [
+        "しんかんせん",
+        "しんかんせん",
+        "bullet train"
+      ],
+      [
+        "ふね",
+        "ふね",
+        "ship/boat"
+      ],
+      [
+        "あるく",
+        "あるく",
+        "walk"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜で　いきます",
+      "meaning": "I go by ~",
+      "example_jp": "まいにち　ちかてつで　かいしゃに　いきます",
+      "example_en": "I go to work by subway every day"
+    },
+    "practice": "Describe how you get to different places: school, supermarket, airport.",
+    "tip": "Japan's public transport is world-famous for punctuality! The しんかんせん (bullet train) is a must-try experience."
+  },
+  {
+    "day": 132,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 20,
+    "title": "Time Expressions",
+    "intro": "Advanced time expressions for nuanced conversations.",
+    "type": "lesson",
+    "chars": [
+      [
+        "いつも",
+        "always"
+      ],
+      [
+        "よく",
+        "often"
+      ],
+      [
+        "ときどき",
+        "sometimes"
+      ],
+      [
+        "めったに〜ない",
+        "rarely"
+      ],
+      [
+        "ぜんぜん〜ない",
+        "never"
+      ]
+    ],
+    "vocab": [
+      [
+        "もうすぐ",
+        "もうすぐ",
+        "soon/almost time"
+      ],
+      [
+        "まだ",
+        "まだ",
+        "still/not yet"
+      ],
+      [
+        "もう",
+        "もう",
+        "already/anymore"
+      ],
+      [
+        "さっき",
+        "さっき",
+        "just now/a moment ago"
+      ],
+      [
+        "あとで",
+        "あとで",
+        "later"
+      ]
+    ],
+    "grammar": {
+      "pattern": "まだ〜ていません",
+      "meaning": "haven't ~ yet",
+      "example_jp": "まだ　あさごはんを　たべていません",
+      "example_en": "I haven't eaten breakfast yet"
+    },
+    "practice": "Write sentences using each time expression.",
+    "tip": "まだ+negative = not yet. もう+negative = not anymore. もう+positive = already. Three meanings with two words — context is key!"
+  },
+  {
+    "day": 133,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 20,
+    "title": "Technology & Modern Life",
+    "intro": "Modern technology vocabulary essential for daily life.",
+    "type": "lesson",
+    "chars": [
+      [
+        "スマートフォン",
+        "smartphone"
+      ],
+      [
+        "コンピューター",
+        "computer"
+      ],
+      [
+        "インターネット",
+        "internet"
+      ],
+      [
+        "メール",
+        "email"
+      ],
+      [
+        "アプリ",
+        "app"
+      ]
+    ],
+    "vocab": [
+      [
+        "SNS",
+        "SNS",
+        "social media"
+      ],
+      [
+        "ダウンロード",
+        "ダウンロード",
+        "download"
+      ],
+      [
+        "パスワード",
+        "パスワード",
+        "password"
+      ],
+      [
+        "じゅうでん",
+        "じゅうでん",
+        "charging (battery)"
+      ],
+      [
+        "でんぱ",
+        "でんぱ",
+        "signal/radio waves"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　つかっています",
+      "meaning": "I use ~",
+      "example_jp": "まいにち　スマートフォンで　メールを　よみます",
+      "example_en": "I read email on my smartphone every day"
+    },
+    "practice": "Write how you use technology in your daily life.",
+    "tip": "Japan is tech-savvy! IC cards (like Suica) for transport, cashless payments, and LINE (messaging app) are part of daily life."
+  },
+  {
+    "day": 134,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 20,
+    "title": "Clothing",
+    "intro": "Clothing vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "シャツ",
+        "shirt"
+      ],
+      [
+        "ズボン",
+        "pants/trousers"
+      ],
+      [
+        "スカート",
+        "skirt"
+      ],
+      [
+        "くつ",
+        "shoes"
+      ],
+      [
+        "ぼうし",
+        "hat"
+      ]
+    ],
+    "vocab": [
+      [
+        "うわぎ",
+        "うわぎ",
+        "jacket/top"
+      ],
+      [
+        "コート",
+        "コート",
+        "coat"
+      ],
+      [
+        "ふく",
+        "ふく",
+        "clothes"
+      ],
+      [
+        "おしゃれ(な)",
+        "おしゃれ(な)",
+        "fashionable"
+      ],
+      [
+        "サイズ",
+        "サイズ",
+        "size"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　きています",
+      "meaning": "wearing ~ (upper body)",
+      "example_jp": "きょう　あかい　シャツを　きています",
+      "example_en": "Today I'm wearing a red shirt"
+    },
+    "practice": "Describe what you're wearing today and what you usually wear.",
+    "tip": "着る (きる) = wear (upper body clothes). はく = wear (lower body: pants, shoes). かぶる = wear (head: hats). Different verbs for different body parts!"
+  },
+  {
+    "day": 135,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 21,
+    "title": "Money & Numbers Review",
+    "intro": "Money expressions and large number practice.",
+    "type": "lesson",
+    "chars": [
+      [
+        "おかね",
+        "money"
+      ],
+      [
+        "さいふ",
+        "wallet"
+      ],
+      [
+        "りょうがえ",
+        "currency exchange"
+      ],
+      [
+        "ぜいきん",
+        "tax"
+      ],
+      [
+        "むりょう",
+        "free (no charge)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜えん",
+        "〜えん",
+        "~ yen"
+      ],
+      [
+        "〜ドル",
+        "〜ドル",
+        "~ dollars"
+      ],
+      [
+        "たかい",
+        "たかい",
+        "expensive"
+      ],
+      [
+        "やすい",
+        "やすい",
+        "cheap"
+      ],
+      [
+        "ただ",
+        "ただ",
+        "free (slang)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜えんです",
+      "meaning": "It is ~ yen",
+      "example_jp": "このくつは　いちまんえんです。たかい！",
+      "example_en": "These shoes are 10,000 yen. Expensive!"
+    },
+    "practice": "Practice: how would you say prices in a Japanese shop? ¥1,500, ¥8,000, ¥23,400.",
+    "tip": "Japan is largely a cash society, though カード (card) payment is now common. Always carry some cash!"
+  },
+  {
+    "day": 136,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 21,
+    "title": "Food Culture",
+    "intro": "Japanese food culture and dining customs.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "いただきます",
+        "いただきます",
+        "let's eat (before meals)"
+      ],
+      [
+        "ごちそうさまでした",
+        "ごちそうさまでした",
+        "thank you for the meal"
+      ],
+      [
+        "わりかん",
+        "わりかん",
+        "splitting the bill"
+      ],
+      [
+        "おごる",
+        "おごる",
+        "treat someone"
+      ],
+      [
+        "〜をたのむ",
+        "〜をたのむ",
+        "to order ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　たのみましょうか",
+      "meaning": "Shall we order ~?",
+      "example_jp": "なにを　たのみますか。わたしはラーメンに　します",
+      "example_en": "What will you order? I'll have ramen"
+    },
+    "practice": "Practice a restaurant dialogue from start to finish: entering, ordering, paying.",
+    "tip": "Japanese dining etiquette: don't stick chopsticks upright in rice (funeral symbolism), don't pass food chopstick to chopstick (also funeral custom). Learn the taboos!"
+  },
+  {
+    "day": 137,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 21,
+    "title": "Health & Body Care",
+    "intro": "Health maintenance and body care vocabulary.",
+    "type": "lesson",
+    "chars": [
+      [
+        "うんどう",
+        "exercise"
+      ],
+      [
+        "たいそう",
+        "calisthenics/gymnastics"
+      ],
+      [
+        "ダイエット",
+        "diet"
+      ],
+      [
+        "すいみん",
+        "sleep"
+      ],
+      [
+        "えいよう",
+        "nutrition"
+      ]
+    ],
+    "vocab": [
+      [
+        "けんこう(な)",
+        "けんこう(な)",
+        "healthy"
+      ],
+      [
+        "からだにいい",
+        "からだにいい",
+        "good for health"
+      ],
+      [
+        "からだにわるい",
+        "からだにわるい",
+        "bad for health"
+      ],
+      [
+        "ストレス",
+        "ストレス",
+        "stress"
+      ],
+      [
+        "きゅうけい",
+        "きゅうけい",
+        "rest/break"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜は　からだに　いいです",
+      "meaning": "~ is good for your body/health",
+      "example_jp": "まいにち　うんどうすることは　からだに　いいです",
+      "example_en": "Exercising every day is good for your body"
+    },
+    "practice": "Write 5 health tips in Japanese.",
+    "tip": "Japanese people rank among the world's longest-lived. Habits: walking, balanced diet (washoku/和食), regular work and social connection."
+  },
+  {
+    "day": 138,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 21,
+    "title": "At the Post Office & Bank",
+    "intro": "Post office and bank vocabulary — practical for life in Japan.",
+    "type": "lesson",
+    "chars": [
+      [
+        "ゆうびんきょく",
+        "post office"
+      ],
+      [
+        "きって",
+        "stamp"
+      ],
+      [
+        "てがみ",
+        "letter"
+      ],
+      [
+        "こづつみ",
+        "package"
+      ],
+      [
+        "ぎんこう",
+        "bank"
+      ]
+    ],
+    "vocab": [
+      [
+        "こうざ",
+        "こうざ",
+        "bank account"
+      ],
+      [
+        "おろす",
+        "おろす",
+        "withdraw money"
+      ],
+      [
+        "ふりこむ",
+        "ふりこむ",
+        "transfer money"
+      ],
+      [
+        "ATM",
+        "ATM",
+        "ATM"
+      ],
+      [
+        "てすうりょう",
+        "てすうりょう",
+        "service fee"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　おくりたいのですが",
+      "meaning": "I'd like to send ~",
+      "example_jp": "この　こづつみを　アメリカに　おくりたいのですが",
+      "example_en": "I'd like to send this package to America"
+    },
+    "practice": "Practice: how do you ask to send a package? open a bank account? withdraw money?",
+    "tip": "Japanese post offices (郵便局) also function as banks! Very convenient for opening an account as a foreigner."
+  },
+  {
+    "day": 139,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 21,
+    "title": "Review: Verbs & Vocabulary",
+    "intro": "Comprehensive review of all Phase 4 vocabulary with JLPT-style exercises.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "にほんごで　いってください",
+        "にほんごで　いってください",
+        "please say it in Japanese"
+      ],
+      [
+        "もういちど",
+        "もういちど",
+        "once more / again"
+      ],
+      [
+        "わすれました",
+        "わすれました",
+        "I forgot"
+      ],
+      [
+        "もうすこし",
+        "もうすこし",
+        "a little more"
+      ],
+      [
+        "じゅうぶんです",
+        "じゅうぶんです",
+        "that's enough / sufficient"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT vocabulary exercise",
+      "meaning": "Practice matching",
+      "example_jp": "つぎのことばの　いみを　えらんでください",
+      "example_en": "Please choose the meaning of the following word"
+    },
+    "practice": "Take a self-quiz: cover the English column and test yourself on all Phase 4 vocabulary.",
+    "tip": "JLPT N5 requires ~800 vocabulary words. You're building that foundation now. Flash cards (Anki) are a powerful tool for retention!"
+  },
+  {
+    "day": 140,
+    "phaseNum": 4,
+    "phaseName": "Vocabulary",
+    "week": 21,
+    "title": "Vocabulary Phase Complete!",
+    "intro": "Congratulations — you've completed Phase 4! Review and celebrate your progress.",
+    "type": "lesson",
+    "chars": [],
+    "vocab": [
+      [
+        "おめでとうございます",
+        "おめでとうございます",
+        "congratulations!"
+      ],
+      [
+        "よくできました",
+        "よくできました",
+        "well done!"
+      ],
+      [
+        "もっとがんばります",
+        "もっとがんばります",
+        "I'll work even harder"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ],
+      [
+        "にほんご",
+        "にほんご",
+        "Japanese language"
+      ],
+      [
+        "たんご",
+        "たんご",
+        "vocabulary word"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　がんばっています",
+      "meaning": "I'm working hard at ~",
+      "example_jp": "まいにち　にほんごを　がんばって　べんきょうしています",
+      "example_en": "I work hard at studying Japanese every day"
+    },
+    "practice": "Write a reflection: What vocabulary surprised you? What do you want to practice more?",
+    "tip": "You've completed 140 days! You now have a strong vocabulary base. Phase 5 tackles verb conjugation — the key to expressing actions and experiences in Japanese!"
+  },
+  {
+    "day": 141,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 21,
+    "title": "Verb Groups: RU-verbs",
+    "intro": "Japanese verbs fall into groups. RU-verbs (Group 2): drop る, add ます. Easy!",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべる→たべます",
+        "eat"
+      ],
+      [
+        "みる→みます",
+        "see/watch"
+      ],
+      [
+        "おきる→おきます",
+        "wake up"
+      ],
+      [
+        "ねる→ねます",
+        "sleep"
+      ],
+      [
+        "でる→でます",
+        "exit/leave"
+      ]
+    ],
+    "vocab": [
+      [
+        "おしえる",
+        "おしえます",
+        "teach"
+      ],
+      [
+        "おぼえる",
+        "おぼえます",
+        "memorise"
+      ],
+      [
+        "かりる",
+        "かります",
+        "borrow"
+      ],
+      [
+        "しめる",
+        "しめます",
+        "close"
+      ],
+      [
+        "あける",
+        "あけます",
+        "open"
+      ]
+    ],
+    "grammar": {
+      "pattern": "RU-verb: stem + ます",
+      "meaning": "Polite present/future",
+      "example_jp": "まいにち　にほんごを　べんきょうします",
+      "example_en": "I study Japanese every day"
+    },
+    "practice": "List 10 RU-verbs and conjugate them: ます、ません、ました、ませんでした.",
+    "tip": "Rule: RU-verbs end in る after an e or i sound: たべ+る, み+る, お+き+る. But careful — some う-verbs also end in る (e.g. はしる = run)!"
+  },
+  {
+    "day": 142,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 21,
+    "title": "More RU-verbs",
+    "intro": "Expanding RU-verb vocabulary.",
+    "type": "verbs",
+    "chars": [
+      [
+        "きる→きます",
+        "wear (clothing)"
+      ],
+      [
+        "おりる→おります",
+        "get off (transport)"
+      ],
+      [
+        "かける→かけます",
+        "hang/dial"
+      ],
+      [
+        "つける→つけます",
+        "turn on"
+      ],
+      [
+        "かえる→かえます",
+        "change"
+      ]
+    ],
+    "vocab": [
+      [
+        "すてる",
+        "すてます",
+        "throw away"
+      ],
+      [
+        "やめる",
+        "やめます",
+        "quit/stop"
+      ],
+      [
+        "はじめる",
+        "はじめます",
+        "start/begin"
+      ],
+      [
+        "おえる",
+        "おえます",
+        "finish"
+      ],
+      [
+        "あつめる",
+        "あつめます",
+        "collect"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜を　はじめます/おえます",
+      "meaning": "start/finish ~",
+      "example_jp": "しごとを　くじに　はじめて、ごじに　おえます",
+      "example_en": "I start work at 9 and finish at 5"
+    },
+    "practice": "Conjugate all 10 verbs above in all 4 polite forms.",
+    "tip": "はじめる (start) vs はじまる (starts by itself). This transitive/intransitive pair is important! Many Japanese verbs come in such pairs."
+  },
+  {
+    "day": 143,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 22,
+    "title": "U-verbs: Introduction",
+    "intro": "U-verbs (Group 1) conjugate by changing the final sound of the stem.",
+    "type": "verbs",
+    "chars": [
+      [
+        "かく→かきます",
+        "write"
+      ],
+      [
+        "よむ→よみます",
+        "read"
+      ],
+      [
+        "のむ→のみます",
+        "drink"
+      ],
+      [
+        "はなす→はなします",
+        "speak"
+      ],
+      [
+        "かう→かいます",
+        "buy"
+      ]
+    ],
+    "vocab": [
+      [
+        "きく",
+        "ききます",
+        "listen/ask"
+      ],
+      [
+        "まつ",
+        "まちます",
+        "wait"
+      ],
+      [
+        "あそぶ",
+        "あそびます",
+        "play"
+      ],
+      [
+        "おもう",
+        "おもいます",
+        "think"
+      ],
+      [
+        "うごく",
+        "うごきます",
+        "move"
+      ]
+    ],
+    "grammar": {
+      "pattern": "U-verb conjugation: く→き, ぐ→ぎ, す→し, つ→ち, ぬ→に, ぶ→び, む→み, る→り, う→い",
+      "meaning": "Stem change for polite form",
+      "example_jp": "まいにち　にっきを　かきます",
+      "example_en": "I write in a diary every day"
+    },
+    "practice": "Conjugate: かく、よむ、はなす、まつ、かう in all 4 polite forms.",
+    "tip": "U-verb rule: find the dictionary form, identify the last syllable, change it following the い-row pattern, then add ます."
+  },
+  {
+    "day": 144,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 22,
+    "title": "Irregular Verbs: する & くる",
+    "intro": "Only 2 truly irregular verbs in Japanese: する (do) and くる (come).",
+    "type": "verbs",
+    "chars": [
+      [
+        "する→します",
+        "do"
+      ],
+      [
+        "くる→きます",
+        "come"
+      ],
+      [
+        "べんきょうする→します",
+        "study"
+      ],
+      [
+        "りょうこうする→します",
+        "travel"
+      ],
+      [
+        "でんわする→します",
+        "phone"
+      ]
+    ],
+    "vocab": [
+      [
+        "かいものする",
+        "かいものします",
+        "go shopping"
+      ],
+      [
+        "うんどうする",
+        "うんどうします",
+        "exercise"
+      ],
+      [
+        "りょうりする",
+        "りょうりします",
+        "cook"
+      ],
+      [
+        "そうじする",
+        "そうじします",
+        "clean"
+      ],
+      [
+        "せんたくする",
+        "せんたくします",
+        "do laundry"
+      ]
+    ],
+    "grammar": {
+      "pattern": "(noun)する",
+      "meaning": "do (noun)",
+      "example_jp": "まいにち　べんきょうして、うんどうして、りょうりします",
+      "example_en": "Every day I study, exercise, and cook"
+    },
+    "practice": "List 5 する-compound verbs related to your daily life.",
+    "tip": "する compounds are extremely productive! Almost any noun can become a verb by adding する: ゲームする (play games), ドライブする (go for a drive), チェックする (check)."
+  },
+  {
+    "day": 145,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 22,
+    "title": "て-form: RU-verbs",
+    "intro": "The て-form is one of the most versatile forms. RU-verb て-form: drop る, add て. Easy!",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべる→たべて",
+        "eat"
+      ],
+      [
+        "みる→みて",
+        "see"
+      ],
+      [
+        "おきる→おきて",
+        "wake up"
+      ],
+      [
+        "ねる→ねて",
+        "sleep"
+      ],
+      [
+        "でる→でて",
+        "exit"
+      ]
+    ],
+    "vocab": [
+      [
+        "おしえて",
+        "おしえて",
+        "teach (te-form)"
+      ],
+      [
+        "おぼえて",
+        "おぼえて",
+        "memorise (te-form)"
+      ],
+      [
+        "あけて",
+        "あけて",
+        "open (te-form)"
+      ],
+      [
+        "しめて",
+        "しめて",
+        "close (te-form)"
+      ],
+      [
+        "すてて",
+        "すてて",
+        "throw away (te-form)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜て　ください",
+      "meaning": "Please ~",
+      "example_jp": "ここに　すわって　ください",
+      "example_en": "Please sit here"
+    },
+    "practice": "Convert 10 RU-verbs to て-form. Then make てください requests.",
+    "tip": "て-form has MANY uses: requests (てください), sequential actions (〜て〜て), progressive (ている), permission (てもいい), prohibition (てはいけない). Master it!"
+  },
+  {
+    "day": 146,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 22,
+    "title": "て-form: U-verbs",
+    "intro": "U-verb て-form: stem changes! く→いて, ぐ→いで, す→して, つ→って, ぬ→んで, ぶ→んで, む→んで, う→って.",
+    "type": "verbs",
+    "chars": [
+      [
+        "かく→かいて",
+        "write→writing"
+      ],
+      [
+        "よむ→よんで",
+        "read→reading"
+      ],
+      [
+        "のむ→のんで",
+        "drink→drinking"
+      ],
+      [
+        "はなす→はなして",
+        "speak→speaking"
+      ],
+      [
+        "まつ→まって",
+        "wait→waiting"
+      ]
+    ],
+    "vocab": [
+      [
+        "かう→かって",
+        "かって",
+        "buy (te-form)"
+      ],
+      [
+        "きく→きいて",
+        "きいて",
+        "listen (te-form)"
+      ],
+      [
+        "いく→いって",
+        "いって",
+        "go (te-form) *special"
+      ],
+      [
+        "あそぶ→あそんで",
+        "あそんで",
+        "play (te-form)"
+      ],
+      [
+        "かえる→かえって",
+        "かえって",
+        "return (te-form)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜て、〜て、〜ます",
+      "meaning": "Do ~, do ~, do ~",
+      "example_jp": "おきて、シャワーをあびて、ごはんをたべます",
+      "example_en": "(I) wake up, shower, and eat"
+    },
+    "practice": "Convert 10 U-verbs to て-form. Write a morning routine chaining 5 actions with て.",
+    "tip": "Special case: いく (go) → いって (NOT いいて). Just this one exception to remember! All other く verbs follow the rule: く→いて."
+  },
+  {
+    "day": 147,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 22,
+    "title": "て-form: Irregular & Practice",
+    "intro": "て-form of する (して) and くる (きて), plus full practice.",
+    "type": "verbs",
+    "chars": [
+      [
+        "する→して",
+        "do→doing"
+      ],
+      [
+        "くる→きて",
+        "come→coming"
+      ],
+      [
+        "べんきょうする→べんきょうして",
+        "study→studying"
+      ],
+      [
+        "りょうりする→りょうりして",
+        "cook→cooking"
+      ],
+      [
+        "うんどうする→うんどうして",
+        "exercise→exercising"
+      ]
+    ],
+    "vocab": [
+      [
+        "して",
+        "して",
+        "do (te-form)"
+      ],
+      [
+        "きて",
+        "きて",
+        "come (te-form)"
+      ],
+      [
+        "おねがいして",
+        "おねがいして",
+        "please (requesting)"
+      ],
+      [
+        "れんしゅうして",
+        "れんしゅうして",
+        "practice (te-form)"
+      ],
+      [
+        "かくにんして",
+        "かくにんして",
+        "confirm (te-form)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "て-form review",
+      "meaning": "All verb types",
+      "example_jp": "まいにち　はやく　おきて、べんきょうして、うんどうして、りょうりします",
+      "example_en": "Every day I wake up early, study, exercise, and cook"
+    },
+    "practice": "Write a full daily schedule chaining 7+ actions with て-form.",
+    "tip": "て-form mastery is the key to sounding natural in Japanese. Spend extra time today — it's worth it!"
+  },
+  {
+    "day": 148,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 22,
+    "title": "〜ている: Progressive",
+    "intro": "たべている = (I am) eating. ている expresses an ongoing action or resulting state.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべている",
+        "eating"
+      ],
+      [
+        "はなしている",
+        "speaking"
+      ],
+      [
+        "みている",
+        "watching"
+      ],
+      [
+        "はしっている",
+        "running"
+      ],
+      [
+        "まっている",
+        "waiting"
+      ]
+    ],
+    "vocab": [
+      [
+        "いま　なにをしていますか",
+        "いま　なにをしていますか",
+        "What are you doing now?"
+      ],
+      [
+        "ねています",
+        "ねています",
+        "(is) sleeping"
+      ],
+      [
+        "べんきょうしています",
+        "べんきょうしています",
+        "(is) studying"
+      ],
+      [
+        "てをあらっています",
+        "てをあらっています",
+        "washing hands"
+      ],
+      [
+        "あるいています",
+        "あるいています",
+        "walking"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ています",
+      "meaning": "is doing ~ (progressive)",
+      "example_jp": "いま　でんしゃに　のっています",
+      "example_en": "I am currently on the train"
+    },
+    "practice": "Describe what 5 people around you are doing right now.",
+    "tip": "〜ています has TWO uses: ongoing action (たべています = is eating) AND resulting state (けっこんしています = is married). Context tells you which!"
+  },
+  {
+    "day": 149,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 23,
+    "title": "〜ている: Resulting State",
+    "intro": "ている can also describe the state that results from a completed action.",
+    "type": "verbs",
+    "chars": [
+      [
+        "けっこんしている",
+        "be married (state from marrying)"
+      ],
+      [
+        "しっている",
+        "know (state from learning)"
+      ],
+      [
+        "すんでいる",
+        "live (state from moving)"
+      ],
+      [
+        "つとめている",
+        "work at (state from being employed)"
+      ],
+      [
+        "ならっている",
+        "be learning (state of study)"
+      ]
+    ],
+    "vocab": [
+      [
+        "しっています",
+        "しっています",
+        "I know (I have learned)"
+      ],
+      [
+        "しりません",
+        "しりません",
+        "I don't know"
+      ],
+      [
+        "すんでいます",
+        "すんでいます",
+        "I live (in ~)"
+      ],
+      [
+        "けっこんしています",
+        "けっこんしています",
+        "I am married"
+      ],
+      [
+        "もっています",
+        "もっています",
+        "I have / I am holding"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　すんでいます",
+      "meaning": "I live in ~",
+      "example_jp": "いまは　とうきょうに　すんでいます",
+      "example_en": "I currently live in Tokyo"
+    },
+    "practice": "Write 3 sentences using ている for ongoing actions and 3 for resulting states.",
+    "tip": "Important: しっています (I know) vs しりません (I don't know). NOT しっていません! しる is a U-verb used in ている form for 'knowledge state'."
+  },
+  {
+    "day": 150,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 23,
+    "title": "Past Tense Review",
+    "intro": "Comprehensive review of ました, ませんでした, and plain past forms.",
+    "type": "verbs",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ました",
+        "〜ました",
+        "did ~ (polite past)"
+      ],
+      [
+        "〜ませんでした",
+        "〜ませんでした",
+        "didn't ~ (polite past)"
+      ],
+      [
+        "〜た",
+        "〜た",
+        "did ~ (plain past)"
+      ],
+      [
+        "〜なかった",
+        "〜なかった",
+        "didn't ~ (plain past)"
+      ],
+      [
+        "きのう",
+        "きのう",
+        "yesterday"
+      ]
+    ],
+    "grammar": {
+      "pattern": "きのう　〜ました",
+      "meaning": "Yesterday I ~",
+      "example_jp": "きのう　ともだちと　えいがを　みました",
+      "example_en": "Yesterday I watched a movie with a friend"
+    },
+    "practice": "Write about what you did yesterday using 5 different verbs in past tense.",
+    "tip": "Plain past (た-form) is used in casual speech and inside clauses. Polite past (ました) is for polite sentences. Both essential!"
+  },
+  {
+    "day": 151,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 23,
+    "title": "Negative て-form: 〜ないで",
+    "intro": "〜ないでください = Please don't ~. Also used to mean 'without doing ~'.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべないでください",
+        "please don't eat"
+      ],
+      [
+        "みないでください",
+        "please don't watch"
+      ],
+      [
+        "わすれないでください",
+        "please don't forget"
+      ],
+      [
+        "はなさないでください",
+        "please don't speak"
+      ],
+      [
+        "しんぱいしないでください",
+        "please don't worry"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜ないで",
+        "〜ないで",
+        "without doing ~"
+      ],
+      [
+        "ねないで　べんきょうした",
+        "ねないで　べんきょうした",
+        "studied without sleeping"
+      ],
+      [
+        "ごはんをたべないで　きた",
+        "ごはんをたべないで　きた",
+        "came without eating"
+      ],
+      [
+        "しんぱいしないで！",
+        "しんぱいしないで！",
+        "Don't worry!"
+      ],
+      [
+        "あきらめないで！",
+        "あきらめないで！",
+        "Don't give up!"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ないでください",
+      "meaning": "Please don't ~",
+      "example_jp": "ここで　タバコを　すわないでください",
+      "example_en": "Please don't smoke here"
+    },
+    "practice": "Write 5 polite prohibitions using ないでください. Then 3 'without doing' sentences.",
+    "tip": "〜ないでください is softer than 〜てはいけません (must not). Use ないでください for polite requests; てはいけません for rules and prohibitions."
+  },
+  {
+    "day": 152,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 23,
+    "title": "〜たい: Want to Do",
+    "intro": "〜たいです = I want to ~. たい is an い-adjective attached to the verb stem.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべたい",
+        "want to eat"
+      ],
+      [
+        "みたい",
+        "want to see"
+      ],
+      [
+        "いきたい",
+        "want to go"
+      ],
+      [
+        "かいたい",
+        "want to buy"
+      ],
+      [
+        "はなしたい",
+        "want to speak"
+      ]
+    ],
+    "vocab": [
+      [
+        "にほんに　いきたいです",
+        "にほんに　いきたいです",
+        "I want to go to Japan"
+      ],
+      [
+        "にほんごを　はなしたい",
+        "にほんごを　はなしたい",
+        "I want to speak Japanese"
+      ],
+      [
+        "〜たくないです",
+        "〜たくないです",
+        "don't want to ~"
+      ],
+      [
+        "〜たかったです",
+        "〜たかったです",
+        "wanted to ~"
+      ],
+      [
+        "〜たくなかったです",
+        "〜たくなかったです",
+        "didn't want to ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜たいです",
+      "meaning": "I want to ~",
+      "example_jp": "いつか　にほんに　いって、ラーメンを　たべたいです",
+      "example_en": "Someday I want to go to Japan and eat ramen"
+    },
+    "practice": "List 5 things you want to do in Japan.",
+    "tip": "たい conjugates like an い-adjective: たくない (don't want to), たかった (wanted to). Very systematic! But たい only expresses YOUR OWN desires, not guessing others."
+  },
+  {
+    "day": 153,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 23,
+    "title": "〜てもいい: Permission",
+    "intro": "〜てもいいですか = May I ~? 〜てもいいです = You may ~.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべてもいいですか",
+        "may I eat?"
+      ],
+      [
+        "みてもいいですか",
+        "may I see/watch?"
+      ],
+      [
+        "はなしてもいいですか",
+        "may I speak?"
+      ],
+      [
+        "つかってもいいですか",
+        "may I use?"
+      ],
+      [
+        "きいてもいいですか",
+        "may I ask?"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜てもいいですよ",
+        "〜てもいいですよ",
+        "you may ~ (giving permission)"
+      ],
+      [
+        "〜てはいけません",
+        "〜てはいけません",
+        "you must not ~ (prohibition)"
+      ],
+      [
+        "〜てもかまいません",
+        "〜てもかまいません",
+        "I don't mind if you ~"
+      ],
+      [
+        "どうぞ",
+        "どうぞ",
+        "please go ahead"
+      ],
+      [
+        "ちょっと...",
+        "ちょっと...",
+        "that's a bit... (indirect refusal)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜てもいいですか",
+      "meaning": "May I ~?",
+      "example_jp": "しゃしんを　とってもいいですか",
+      "example_en": "May I take a photo?"
+    },
+    "practice": "Practice asking permission in 5 situations: at a restaurant, museum, friend's house, office, shop.",
+    "tip": "In Japan, explicitly asking permission is very important and appreciated. Don't assume — always ask with 〜てもいいですか!"
+  },
+  {
+    "day": 154,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 24,
+    "title": "〜なければなりません: Must",
+    "intro": "〜なければなりません = must do ~. Shortened casual form: 〜なきゃ.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべなければなりません",
+        "must eat"
+      ],
+      [
+        "べんきょうしなければなりません",
+        "must study"
+      ],
+      [
+        "いかなければなりません",
+        "must go"
+      ],
+      [
+        "はやくおきなければなりません",
+        "must wake up early"
+      ],
+      [
+        "かならず〜しなければなりません",
+        "must definitely ~"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜なければなりません",
+        "〜なければなりません",
+        "must ~"
+      ],
+      [
+        "〜なきゃ",
+        "〜なきゃ",
+        "must ~ (casual)"
+      ],
+      [
+        "〜なくてもいいです",
+        "〜なくてもいいです",
+        "don't have to ~"
+      ],
+      [
+        "しなければいけません",
+        "しなければいけません",
+        "must do (alt. form)"
+      ],
+      [
+        "ぎむ",
+        "ぎむ",
+        "obligation"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜なければなりません",
+      "meaning": "must ~",
+      "example_jp": "くすりを　のまなければなりません",
+      "example_en": "I must take medicine"
+    },
+    "practice": "Write 5 obligations using なければなりません (study, work, sleep, exercise, eat).",
+    "tip": "Long but important! Shortcut: Verb ない-form → drop い → add きゃ: たべなきゃ (casual 'gotta eat'). Very common in speech!"
+  },
+  {
+    "day": 155,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 24,
+    "title": "〜なくてもいい: Don't Have To",
+    "intro": "〜なくてもいいです = don't have to ~. Used with permissions and freedoms.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべなくてもいいです",
+        "don't have to eat"
+      ],
+      [
+        "いかなくてもいいです",
+        "don't have to go"
+      ],
+      [
+        "しなくてもいいです",
+        "don't have to do"
+      ],
+      [
+        "はらわなくてもいいです",
+        "don't have to pay"
+      ],
+      [
+        "しんぱいしなくてもいいです",
+        "don't have to worry"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜なくてもいいですよ",
+        "〜なくてもいいですよ",
+        "you don't have to ~"
+      ],
+      [
+        "やすんでもいいですよ",
+        "やすんでもいいですよ",
+        "you may rest"
+      ],
+      [
+        "むりしなくてもいいです",
+        "むりしなくてもいいです",
+        "you don't have to push yourself"
+      ],
+      [
+        "きがるに",
+        "きがるに",
+        "feel free to"
+      ],
+      [
+        "おかまいなく",
+        "おかまいなく",
+        "please don't worry about me"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜なくてもいいです",
+      "meaning": "don't have to ~",
+      "example_jp": "きょうは　かいしゃに　いかなくてもいいです",
+      "example_en": "You don't have to go to the office today"
+    },
+    "practice": "Write 5 situations where you DON'T have to do something (weekend, holiday, etc.).",
+    "tip": "The 4 permission/obligation forms in a nutshell: ていい (may), てはいけない (must not), なければならない (must), なくてもいい (don't have to). Master these 4!"
+  },
+  {
+    "day": 156,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 24,
+    "title": "〜ことができる: Can / Ability",
+    "intro": "〜ことができます = can do ~. Also: できます alone = can, is possible.",
+    "type": "verbs",
+    "chars": [
+      [
+        "にほんごをはなすことができます",
+        "can speak Japanese"
+      ],
+      [
+        "ピアノをひくことができます",
+        "can play piano"
+      ],
+      [
+        "〜ができます",
+        "can do ~"
+      ],
+      [
+        "〜ができません",
+        "cannot do ~"
+      ],
+      [
+        "〜ができましたか",
+        "could you ~? / were you able to ~?"
+      ]
+    ],
+    "vocab": [
+      [
+        "できます",
+        "できます",
+        "can / is possible"
+      ],
+      [
+        "できません",
+        "できません",
+        "cannot"
+      ],
+      [
+        "〜がとくいです",
+        "〜がとくいです",
+        "good at ~"
+      ],
+      [
+        "〜がにがてです",
+        "〜がにがてです",
+        "not good at ~"
+      ],
+      [
+        "れんしゅうすればできます",
+        "れんしゅうすればできます",
+        "with practice you can do it"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ことができます",
+      "meaning": "can ~",
+      "example_jp": "にほんごで　かんたんな　かいわが　できます",
+      "example_en": "I can have a simple conversation in Japanese"
+    },
+    "practice": "List 5 things you can do and 3 things you can't do yet (but want to learn).",
+    "tip": "できます can be used alone: にほんごができます (I can [do] Japanese). ことができます is more formal. Both are common and correct!"
+  },
+  {
+    "day": 157,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 24,
+    "title": "〜てから: After Doing",
+    "intro": "〜てから = after doing ~. Describes a sequence where the first action must complete first.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべてから　はをみがきます",
+        "brush teeth after eating"
+      ],
+      [
+        "しゅくだいをしてから　あそびます",
+        "play after doing homework"
+      ],
+      [
+        "シャワーをあびてから　ねます",
+        "sleep after showering"
+      ],
+      [
+        "にほんに　いってから　わかりました",
+        "understood after going to Japan"
+      ],
+      [
+        "かんがえてから　こたえます",
+        "answer after thinking"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜てから",
+        "〜てから",
+        "after doing ~"
+      ],
+      [
+        "〜たあとで",
+        "〜たあとで",
+        "after ~ (past completed action)"
+      ],
+      [
+        "〜まえに",
+        "〜まえに",
+        "before ~"
+      ],
+      [
+        "じゅんばん",
+        "じゅんばん",
+        "order/sequence"
+      ],
+      [
+        "まず",
+        "まず",
+        "first of all"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜てから　〜ます",
+      "meaning": "After doing ~, do ~",
+      "example_jp": "てを　あらってから　たべましょう",
+      "example_en": "Let's eat after washing our hands"
+    },
+    "practice": "Write 5 sentences showing a sequence of activities in your day.",
+    "tip": "〜てから vs 〜たあとで: てから = immediately after (the order matters). たあとで = sometime after (looser connection). Both are very natural!"
+  },
+  {
+    "day": 158,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 24,
+    "title": "〜まえに: Before Doing",
+    "intro": "〜まえに = before doing ~. The verb before まえに stays in DICTIONARY form.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべるまえに　てをあらいます",
+        "wash hands before eating"
+      ],
+      [
+        "ねるまえに　はをみがきます",
+        "brush teeth before sleeping"
+      ],
+      [
+        "でかけるまえに　かぎをかけます",
+        "lock up before going out"
+      ],
+      [
+        "しけんのまえに　べんきょうします",
+        "study before the exam"
+      ],
+      [
+        "しぬまえに　にほんにいきたい",
+        "want to go to Japan before dying"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜まえに",
+        "〜まえに",
+        "before ~"
+      ],
+      [
+        "じゅんび",
+        "じゅんび",
+        "preparation"
+      ],
+      [
+        "よやく",
+        "よやく",
+        "reservation/booking"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation"
+      ],
+      [
+        "ちゅうい",
+        "ちゅうい",
+        "caution/warning"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜るまえに",
+      "meaning": "before doing ~",
+      "example_jp": "にほんに　いくまえに　にほんごを　べんきょうします",
+      "example_en": "I study Japanese before going to Japan"
+    },
+    "practice": "Write 5 things you do before important events (exam, trip, meeting).",
+    "tip": "KEY: まえに uses DICTIONARY form (たべるまえに), while あとで uses PAST form (たべたあとで). Many students mix these up!"
+  },
+  {
+    "day": 159,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 25,
+    "title": "〜ながら: While Doing",
+    "intro": "〜ながら = while doing ~. Used when two actions happen simultaneously (same subject).",
+    "type": "verbs",
+    "chars": [
+      [
+        "おんがくをききながらべんきょうします",
+        "study while listening to music"
+      ],
+      [
+        "あるきながらたべます",
+        "eat while walking"
+      ],
+      [
+        "テレビをみながらしょくじします",
+        "eat while watching TV"
+      ],
+      [
+        "はなしながらあるきます",
+        "walk while talking"
+      ],
+      [
+        "わらいながらいいました",
+        "said (it) while laughing"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜ながら",
+        "〜ながら",
+        "while doing ~"
+      ],
+      [
+        "どうじに",
+        "どうじに",
+        "at the same time"
+      ],
+      [
+        "〜つつ",
+        "〜つつ",
+        "while ~ (formal)"
+      ],
+      [
+        "いっぽうで",
+        "いっぽうで",
+        "on the other hand"
+      ],
+      [
+        "マルチタスク",
+        "マルチタスク",
+        "multitasking"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ながら　〜ます",
+      "meaning": "do ~ while doing ~",
+      "example_jp": "コーヒーを　のみながら　にほんごを　べんきょうします",
+      "example_en": "I study Japanese while drinking coffee"
+    },
+    "practice": "What do you do simultaneously? List 5 ながら activities.",
+    "tip": "ながら: main action comes AFTER ながら. The action before ながら is the background activity: おんがくを（きき）ながら（べんきょうします）. The study is the focus!"
+  },
+  {
+    "day": 160,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 25,
+    "title": "〜と思います: I Think That",
+    "intro": "〜とおもいます = I think that ~. The clause before と uses plain form.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たかいとおもいます",
+        "I think it's expensive"
+      ],
+      [
+        "いいとおもいます",
+        "I think it's good"
+      ],
+      [
+        "にほんごはむずかしいとおもいます",
+        "I think Japanese is difficult"
+      ],
+      [
+        "かれはきっとくるとおもいます",
+        "I think he will surely come"
+      ],
+      [
+        "わかりませんが、そうだとおもいます",
+        "I'm not sure but I think so"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜とおもいます",
+        "〜とおもいます",
+        "I think that ~"
+      ],
+      [
+        "〜とおもっています",
+        "〜とおもっています",
+        "I have been thinking that ~"
+      ],
+      [
+        "〜かもしれません",
+        "〜かもしれません",
+        "might be / perhaps"
+      ],
+      [
+        "〜でしょう",
+        "〜でしょう",
+        "probably / I think"
+      ],
+      [
+        "〜はずです",
+        "〜はずです",
+        "should be / expected to be"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜とおもいます",
+      "meaning": "I think that ~",
+      "example_jp": "にほんごは　むずかしいですが、たのしいとおもいます",
+      "example_en": "I think Japanese is difficult, but fun"
+    },
+    "practice": "Express 5 opinions using とおもいます.",
+    "tip": "〜とおもいます is essential for polite opinion-giving. Japanese culture values indirect expression — とおもいます softens opinions perfectly!"
+  },
+  {
+    "day": 161,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 25,
+    "title": "〜てあげる・もらう・くれる: Giving & Receiving",
+    "intro": "Three verbs for giving and receiving actions (not objects).",
+    "type": "verbs",
+    "chars": [
+      [
+        "〜てあげます",
+        "do for (outward — I/we → them)"
+      ],
+      [
+        "〜てもらいます",
+        "receive the doing of (I/we ← them)"
+      ],
+      [
+        "〜てくれます",
+        "give to me/us (they → me/us)"
+      ],
+      [
+        "おしえてあげます",
+        "teach (for them)"
+      ],
+      [
+        "てつだってもらいます",
+        "receive help"
+      ]
+    ],
+    "vocab": [
+      [
+        "たすけてくれました",
+        "たすけてくれました",
+        "(they) helped me"
+      ],
+      [
+        "かしてあげました",
+        "かしてあげました",
+        "lent (to them)"
+      ],
+      [
+        "みせてもらいました",
+        "みせてもらいました",
+        "was shown (by them)"
+      ],
+      [
+        "〜てくれてありがとう",
+        "〜てくれてありがとう",
+        "thank you for doing ~"
+      ],
+      [
+        "〜てあげましょうか",
+        "〜てあげましょうか",
+        "Shall I do ~ for you?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜てくれてありがとう",
+      "meaning": "Thank you for ~ing (for me)",
+      "example_jp": "たすけてくれて　ありがとうございます",
+      "example_en": "Thank you for helping me"
+    },
+    "practice": "Write 5 sentences about things done for you, things you did for others.",
+    "tip": "The direction matters! あげる = you give/do for others. もらう = you receive from others. くれる = they give/do FOR YOU. Draw arrows to remember!"
+  },
+  {
+    "day": 162,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 25,
+    "title": "〜に行く: Going to Do",
+    "intro": "〜にいきます = go (somewhere) in order to ~. Express purpose of travel.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべにいきます",
+        "go to eat"
+      ],
+      [
+        "かいものにいきます",
+        "go shopping"
+      ],
+      [
+        "あそびにいきます",
+        "go to play/hang out"
+      ],
+      [
+        "みにいきます",
+        "go to see"
+      ],
+      [
+        "べんきょうしにいきます",
+        "go to study"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜にいく",
+        "〜にいく",
+        "go to do ~"
+      ],
+      [
+        "〜にくる",
+        "〜にくる",
+        "come to do ~"
+      ],
+      [
+        "〜にかえる",
+        "〜にかえる",
+        "return to do ~"
+      ],
+      [
+        "もくてき",
+        "もくてき",
+        "purpose"
+      ],
+      [
+        "〜ために",
+        "〜ために",
+        "for the purpose of ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　いきます",
+      "meaning": "go to do ~",
+      "example_jp": "レストランに　ランチを　たべに　いきます",
+      "example_en": "I'm going to the restaurant to eat lunch"
+    },
+    "practice": "Write 5 sentences about where you go and why (purpose).",
+    "tip": "The structure: place + に + verb stem + に + いきます. 'I go to [place] to [do verb]': スーパーにかいものにいきます = I go to the supermarket to shop."
+  },
+  {
+    "day": 163,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 25,
+    "title": "Verb Review: All Forms",
+    "intro": "Comprehensive review of all verb forms learned in Phase 5 so far.",
+    "type": "verbs",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ます/ません",
+        "〜ます/ません",
+        "present polite"
+      ],
+      [
+        "〜ました/ませんでした",
+        "〜ました/ませんでした",
+        "past polite"
+      ],
+      [
+        "〜て",
+        "〜て",
+        "te-form"
+      ],
+      [
+        "〜ている",
+        "〜ている",
+        "progressive/state"
+      ],
+      [
+        "〜たい",
+        "〜たい",
+        "want to"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Verb conjugation summary",
+      "meaning": "All polite forms",
+      "example_jp": "たべます、たべません、たべました、たべませんでした、たべて、たべている、たべたい",
+      "example_en": "eat, don't eat, ate, didn't eat, eating (te), is eating, want to eat"
+    },
+    "practice": "Make a conjugation table for 5 verbs (one of each type: RU, U, する, くる).",
+    "tip": "Create a verb conjugation cheat sheet! This is the most valuable study tool you can make at this stage."
+  },
+  {
+    "day": 164,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 26,
+    "title": "Plain Form: Present/Future",
+    "intro": "The plain (dictionary) form is used in casual speech and inside clauses.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべる",
+        "eat (plain)"
+      ],
+      [
+        "のむ",
+        "drink (plain)"
+      ],
+      [
+        "いく",
+        "go (plain)"
+      ],
+      [
+        "する",
+        "do (plain)"
+      ],
+      [
+        "くる",
+        "come (plain)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜とおもう",
+        "〜とおもう",
+        "think that ~ (casual)"
+      ],
+      [
+        "〜かもしれない",
+        "〜かもしれない",
+        "might be (casual)"
+      ],
+      [
+        "〜んだ",
+        "〜んだ",
+        "explanation (casual)"
+      ],
+      [
+        "〜よね",
+        "〜よね",
+        "right? (seeking agreement)"
+      ],
+      [
+        "〜でしょ",
+        "〜でしょ",
+        "right? (asserting)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜と　おもう (casual)",
+      "meaning": "I think ~ (casual)",
+      "example_jp": "あしたは　あめが　ふると　おもう",
+      "example_en": "I think it'll rain tomorrow"
+    },
+    "practice": "Practice writing in casual (plain) form — as if texting a friend.",
+    "tip": "Casual Japanese drops ます/です and uses plain forms. Essential for understanding anime, manga, and conversations among friends!"
+  },
+  {
+    "day": 165,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 26,
+    "title": "Plain Negative: ない-form",
+    "intro": "Plain negative form: ない-form. RU-verbs: drop る, add ない. U-verbs: change to あ-row + ない.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべない",
+        "don't eat (plain)"
+      ],
+      [
+        "みない",
+        "don't see (plain)"
+      ],
+      [
+        "いかない",
+        "don't go (plain)"
+      ],
+      [
+        "しない",
+        "don't do (plain)"
+      ],
+      [
+        "こない",
+        "don't come (plain)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜ないとおもう",
+        "〜ないとおもう",
+        "think won't ~"
+      ],
+      [
+        "〜ないかもしれない",
+        "〜ないかもしれない",
+        "might not ~"
+      ],
+      [
+        "〜なければ",
+        "〜なければ",
+        "if not ~ / must ~"
+      ],
+      [
+        "〜ないで",
+        "〜ないで",
+        "without doing"
+      ],
+      [
+        "〜ずに",
+        "〜ずに",
+        "without doing (formal)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ないとおもいます",
+      "meaning": "I don't think ~ will ~",
+      "example_jp": "かれは　こないとおもいます",
+      "example_en": "I don't think he'll come"
+    },
+    "practice": "Conjugate 10 verbs to plain negative form.",
+    "tip": "U-verb ない rule: change the final う-sound to あ-row: く→かない, ぐ→がない, す→さない, つ→たない, ぬ→なない, ぶ→ばない, む→まない, う→わない (NOT あない!)"
+  },
+  {
+    "day": 166,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 26,
+    "title": "Plain Past: た-form",
+    "intro": "た-form (plain past) is formed the same way as て-form but with た/だ instead of て/で.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべた",
+        "ate (plain)"
+      ],
+      [
+        "みた",
+        "saw (plain)"
+      ],
+      [
+        "いった",
+        "went (plain)"
+      ],
+      [
+        "した",
+        "did (plain)"
+      ],
+      [
+        "きた",
+        "came (plain)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜たとおもいます",
+        "〜たとおもいます",
+        "I think ~ happened"
+      ],
+      [
+        "〜たことがあります",
+        "〜たことがあります",
+        "have experienced ~"
+      ],
+      [
+        "〜たあとで",
+        "〜たあとで",
+        "after ~"
+      ],
+      [
+        "〜たら",
+        "〜たら",
+        "if/when ~ (conditional)"
+      ],
+      [
+        "〜たり〜たりします",
+        "〜たり〜たりします",
+        "do things like ~ and ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜たことがあります",
+      "meaning": "I have experienced ~",
+      "example_jp": "にほんに　いったことが　あります",
+      "example_en": "I have been to Japan (before)"
+    },
+    "practice": "Write 5 experiences you have had using 〜たことがあります.",
+    "tip": "〜たことがあります expresses LIFE EXPERIENCE: 'I have (at some point in my life) done ~'. This is different from just 'I did ~' (past tense). Very useful for conversation!"
+  },
+  {
+    "day": 167,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 26,
+    "title": "〜たり〜たりする: Listing Actions",
+    "intro": "〜たり〜たりします = do things like ~ and ~. Used to give examples of activities (not exhaustive list).",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべたり　のんだりします",
+        "eat and drink (and things like that)"
+      ],
+      [
+        "よんだり　かいたりします",
+        "read and write (etc.)"
+      ],
+      [
+        "いったり　きたりします",
+        "go and come (back and forth)"
+      ],
+      [
+        "うたったり　おどったりします",
+        "sing and dance (etc.)"
+      ],
+      [
+        "やすんだり　あそんだりします",
+        "rest and play (etc.)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜たり〜たりします",
+        "〜たり〜たりします",
+        "do ~ and ~ (etc.)"
+      ],
+      [
+        "〜たりして",
+        "〜たりして",
+        "doing things like ~"
+      ],
+      [
+        "なにかと",
+        "なにかと",
+        "this and that"
+      ],
+      [
+        "いろいろ",
+        "いろいろ",
+        "various things"
+      ],
+      [
+        "たとえば",
+        "たとえば",
+        "for example"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜たり、〜たりします",
+      "meaning": "do things like ~ and ~",
+      "example_jp": "しゅうまつは　えいがをみたり、ともだちとあそんだりします",
+      "example_en": "On weekends I do things like watch movies and hang out with friends"
+    },
+    "practice": "Describe your typical weekend using たり〜たりします.",
+    "tip": "〜たり〜たりします implies the list is NOT complete — 'among other things'. Use it when giving examples, not exhaustive lists. Very natural in conversation!"
+  },
+  {
+    "day": 168,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 27,
+    "title": "〜ば: Conditional (If)",
+    "intro": "〜ば = if ~. Used for hypothetical conditions. Verb: change final sound to え-row + ば.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべれば",
+        "if (you) eat"
+      ],
+      [
+        "いけば",
+        "if (you) go"
+      ],
+      [
+        "すれば",
+        "if (you) do"
+      ],
+      [
+        "くれば",
+        "if (you) come"
+      ],
+      [
+        "あれば",
+        "if there is"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜ばよかった",
+        "〜ばよかった",
+        "I should have ~ / wish I had ~"
+      ],
+      [
+        "〜ばいい",
+        "〜ばいい",
+        "should ~ / it's fine if ~"
+      ],
+      [
+        "〜ければ",
+        "〜ければ",
+        "if (i-adj)"
+      ],
+      [
+        "〜なら",
+        "〜なら",
+        "if ~ is the case"
+      ],
+      [
+        "〜たら",
+        "〜たら",
+        "if/when ~ (completed)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ばよかった",
+      "meaning": "I should have ~ / I wish I had ~",
+      "example_jp": "もっとはやく　べんきょうすれば　よかった",
+      "example_en": "I should have studied earlier"
+    },
+    "practice": "Write 3 regrets using 〜ばよかった and 3 advice sentences using 〜ばいい.",
+    "tip": "〜ばよかった is a very common expression of regret: もっと〜ばよかった (I should have done more ~). You'll use it often!"
+  },
+  {
+    "day": 169,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 27,
+    "title": "〜たら: Conditional (When/If)",
+    "intro": "〜たら = if/when ~. Used for both hypothetical and real future conditions. た-form + ら.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべたら",
+        "if/when (you) eat/ate"
+      ],
+      [
+        "いったら",
+        "if/when (you) go/went"
+      ],
+      [
+        "したら",
+        "if/when (you) do/did"
+      ],
+      [
+        "きたら",
+        "if/when (you) come/came"
+      ],
+      [
+        "あったら",
+        "if/when there is/was"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜たら　どうですか",
+        "〜たら　どうですか",
+        "how about doing ~?"
+      ],
+      [
+        "〜たら　おしえてください",
+        "〜たら　おしえてください",
+        "let me know when ~"
+      ],
+      [
+        "もし〜たら",
+        "もし〜たら",
+        "if (hypothetical)"
+      ],
+      [
+        "〜たら、〜た",
+        "〜たら、〜た",
+        "when I did ~, ~ happened"
+      ],
+      [
+        "〜たらいいですか",
+        "〜たらいいですか",
+        "what should I do?"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜たら　どうですか",
+      "meaning": "How about ~ing?",
+      "example_jp": "いしゃに　いったら　どうですか",
+      "example_en": "How about going to a doctor?"
+    },
+    "practice": "Write 5 sentences using たら for advice, conditions, and sequences.",
+    "tip": "〜たらどうですか is a great advice-giving phrase: 'Why don't you ~?' Very useful and polite!"
+  },
+  {
+    "day": 170,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 27,
+    "title": "〜と: Natural Consequence",
+    "intro": "〜と = when/if ~ [natural/inevitable result]. Used for habitual truths and logical outcomes.",
+    "type": "verbs",
+    "chars": [
+      [
+        "みぎにまがると、えきがあります",
+        "if you turn right, there's a station"
+      ],
+      [
+        "はるになると、さくらがさきます",
+        "when spring comes, cherry blossoms bloom"
+      ],
+      [
+        "これをおすと、でます",
+        "when you press this, it comes out"
+      ],
+      [
+        "おさけをのみすぎると、からだによくない",
+        "drinking too much alcohol is bad for you"
+      ],
+      [
+        "まいにちれんしゅうすると、うまくなります",
+        "if you practice every day, you'll get better"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜と",
+        "〜と",
+        "when/if ~ (natural consequence)"
+      ],
+      [
+        "かならず",
+        "かならず",
+        "certainly/definitely"
+      ],
+      [
+        "しぜんに",
+        "しぜんに",
+        "naturally"
+      ],
+      [
+        "〜のは〜だから",
+        "〜のは〜だから",
+        "the reason ~ is because ~"
+      ],
+      [
+        "〜というのは",
+        "〜というのは",
+        "what is called ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜と、〜ます",
+      "meaning": "When/if ~, ~ (natural result)",
+      "example_jp": "にほんに　いくと、おいしいものが　たくさん　あります",
+      "example_en": "When you go to Japan, there are many delicious things"
+    },
+    "practice": "Write 5 natural consequences using と.",
+    "tip": "〜と is for INEVITABLE or NATURAL results. Don't use it for choices or requests. Compare: えきにつくと、でんわします (When I arrive at the station, I'll call — natural) vs えきにつきたら、でんわしてください (When you arrive at the station, please call — request)."
+  },
+  {
+    "day": 171,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 27,
+    "title": "Verb Phase Review 1",
+    "intro": "Review of て-form uses, ている, permission/obligation forms.",
+    "type": "verbs",
+    "chars": [],
+    "vocab": [
+      [
+        "てください",
+        "てください",
+        "please do"
+      ],
+      [
+        "てはいけない",
+        "てはいけない",
+        "must not"
+      ],
+      [
+        "てもいい",
+        "てもいい",
+        "may / it's OK to"
+      ],
+      [
+        "なければならない",
+        "なければならない",
+        "must do"
+      ],
+      [
+        "なくてもいい",
+        "なくてもいい",
+        "don't have to"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Quick quiz: how do you say...",
+      "meaning": "Permission/obligation review",
+      "example_jp": "しずかにしてください。ここでたべてはいけません。〜してもいいですか。",
+      "example_en": "Please be quiet. You must not eat here. May I ~?"
+    },
+    "practice": "Make a table of the 5 permission/obligation forms with one example each.",
+    "tip": "These 5 forms are essential for JLPT N5. Make flashcards: てください/てはいけない/てもいい/なければならない/なくてもいい"
+  },
+  {
+    "day": 172,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 28,
+    "title": "Verb Phase Review 2",
+    "intro": "Review of conditional forms and giving/receiving.",
+    "type": "verbs",
+    "chars": [],
+    "vocab": [
+      [
+        "てから",
+        "てから",
+        "after doing"
+      ],
+      [
+        "まえに",
+        "まえに",
+        "before doing"
+      ],
+      [
+        "たら",
+        "たら",
+        "if/when (conditional)"
+      ],
+      [
+        "ば",
+        "ば",
+        "if (hypothetical)"
+      ],
+      [
+        "と",
+        "と",
+        "when/if (natural result)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Conditional comparison",
+      "meaning": "When to use each conditional",
+      "example_jp": "ごはんをたべてから、はをみがきます。／ねるまえに、はをみがきます",
+      "example_en": "I brush my teeth after eating. / I brush my teeth before sleeping"
+    },
+    "practice": "Write a mini-story using at least 3 different conditional/sequential forms.",
+    "tip": "All 4 conditionals (たら、ば、と、なら) have different nuances. Don't stress — with practice, the right one becomes intuitive!"
+  },
+  {
+    "day": 173,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 28,
+    "title": "〜んです/のです: Explanation",
+    "intro": "〜んです = explanatory form. Provides context or explains a situation. Very common in speech.",
+    "type": "verbs",
+    "chars": [
+      [
+        "どうしたんですか",
+        "what happened? / what's wrong?"
+      ],
+      [
+        "あたまがいたいんです",
+        "the thing is, I have a headache"
+      ],
+      [
+        "ちょっとわからないんですが",
+        "I don't quite understand, you see"
+      ],
+      [
+        "じつは〜んです",
+        "actually, it's that ~"
+      ],
+      [
+        "〜んですね",
+        "〜んですね"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜んです",
+        "〜んです",
+        "explanation/context (です after の/ん)"
+      ],
+      [
+        "じつは",
+        "じつは",
+        "actually / in fact"
+      ],
+      [
+        "〜んですが",
+        "〜んですが",
+        "the thing is ~ (leading to request)"
+      ],
+      [
+        "〜んですよね",
+        "〜んですよね",
+        "I see, that's right isn't it"
+      ],
+      [
+        "そうなんです",
+        "そうなんです",
+        "That's right / yes that's the thing"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜んです",
+      "meaning": "explanatory form (the thing is ~)",
+      "example_jp": "きょう　がっこうを　やすんだんです。かぜを　ひいたんです",
+      "example_en": "The thing is I skipped school today. I caught a cold, you see"
+    },
+    "practice": "Write 5 explanatory sentences using 〜んです about why you did or didn't do something.",
+    "tip": "〜んです is incredibly common in natural Japanese speech but rarely in textbooks. Mastering it makes you sound much more natural!"
+  },
+  {
+    "day": 174,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 28,
+    "title": "〜そうです: Hearsay vs Appearance",
+    "intro": "Two meanings: 〜そうです① = I heard that ~ (hearsay). 〜そうです② = looks like ~ / seems ~ (appearance).",
+    "type": "verbs",
+    "chars": [
+      [
+        "あめがふりそうです",
+        "it looks like it will rain (appearance)"
+      ],
+      [
+        "かれはげんきそうです",
+        "he looks healthy (appearance)"
+      ],
+      [
+        "あのレストランはおいしいそうです",
+        "I heard that restaurant is good (hearsay)"
+      ],
+      [
+        "にほんごはむずかしいそうです",
+        "I heard Japanese is difficult (hearsay)"
+      ],
+      [
+        "かなしそうです",
+        "looks sad (appearance)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜そうです (appearance)",
+        "〜そうです",
+        "looks like ~ / seems ~"
+      ],
+      [
+        "〜そうです (hearsay)",
+        "〜そうです",
+        "I heard that ~"
+      ],
+      [
+        "〜らしいです",
+        "〜らしいです",
+        "apparently ~ / I heard that ~"
+      ],
+      [
+        "〜ようです",
+        "〜ようです",
+        "it seems that ~"
+      ],
+      [
+        "〜みたいです",
+        "〜みたいです",
+        "looks like ~ (casual)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜そうです (both)",
+      "meaning": "looks like ~ / I heard that ~",
+      "example_jp": "そとは　さむそうです。コートを　きていったほうが　いいですよ",
+      "example_en": "It looks cold outside. You'd better wear a coat"
+    },
+    "practice": "Write 3 appearance 〜そうです and 3 hearsay 〜そうです sentences.",
+    "tip": "KEY: Appearance そうです uses verb/adj STEM + そうです (おいし+そう). Hearsay そうです uses PLAIN FORM + そうです (おいしい+そうです). Watch the form!"
+  },
+  {
+    "day": 175,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 28,
+    "title": "〜すぎる: Too Much",
+    "intro": "〜すぎます = too much ~, do ~ too much.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべすぎます",
+        "eat too much"
+      ],
+      [
+        "のみすぎます",
+        "drink too much"
+      ],
+      [
+        "はたらきすぎます",
+        "work too much"
+      ],
+      [
+        "たかすぎます",
+        "too expensive (adj)"
+      ],
+      [
+        "むずかしすぎます",
+        "too difficult (adj)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜すぎて",
+        "〜すぎて",
+        "because of doing ~ too much"
+      ],
+      [
+        "〜すぎないように",
+        "〜すぎないように",
+        "so as not to ~ too much"
+      ],
+      [
+        "ほどほどに",
+        "ほどほどに",
+        "in moderation"
+      ],
+      [
+        "やりすぎ",
+        "やりすぎ",
+        "overdoing it"
+      ],
+      [
+        "〜すぎた",
+        "〜すぎた",
+        "did ~ too much (past)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜すぎます",
+      "meaning": "too much ~",
+      "example_jp": "きのうは　たべすぎて、おなかが　いたいです",
+      "example_en": "I ate too much yesterday and my stomach hurts"
+    },
+    "practice": "Write 5 sentences using すぎます for actions or adjectives.",
+    "tip": "すぎます: verb stem + すぎます (たべ+すぎ), i-adj stem + すぎます (むずかし+すぎ), na-adj + すぎます (しずか+すぎ). Applies to all word types!"
+  },
+  {
+    "day": 176,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 29,
+    "title": "〜やすい・〜にくい: Easy/Hard to Do",
+    "intro": "〜やすいです = easy to do. 〜にくいです = hard to do.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべやすいです",
+        "easy to eat"
+      ],
+      [
+        "わかりやすいです",
+        "easy to understand"
+      ],
+      [
+        "つかいやすいです",
+        "easy to use"
+      ],
+      [
+        "よみにくいです",
+        "hard to read"
+      ],
+      [
+        "はなしにくいです",
+        "hard to speak"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜やすい",
+        "〜やすい",
+        "easy to ~ / tends to ~"
+      ],
+      [
+        "〜にくい",
+        "〜にくい",
+        "hard to ~ / difficult to ~"
+      ],
+      [
+        "べんり(な)",
+        "べんり(な)",
+        "convenient"
+      ],
+      [
+        "〜しやすい　かんきょう",
+        "〜しやすい　かんきょう",
+        "environment easy to ~"
+      ],
+      [
+        "〜しにくい",
+        "〜しにくい",
+        "hard to do ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜やすいです / 〜にくいです",
+      "meaning": "easy/hard to ~",
+      "example_jp": "このほんは　わかりやすくて、べんきょうしやすいです",
+      "example_en": "This book is easy to understand and easy to study from"
+    },
+    "practice": "Rate 5 things in your life: easy or hard to do?",
+    "tip": "やすい and にくい attach to the verb STEM (before ます): たべ+やすい, はなし+にくい. Very productive pattern in Japanese!"
+  },
+  {
+    "day": 177,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 29,
+    "title": "〜ほうがいい: Should / Better To",
+    "intro": "〜ほうがいい = it would be better to ~. Used for advice and recommendations.",
+    "type": "verbs",
+    "chars": [
+      [
+        "いったほうがいいです",
+        "you should go"
+      ],
+      [
+        "たべたほうがいいです",
+        "you should eat"
+      ],
+      [
+        "ねたほうがいいです",
+        "you should sleep"
+      ],
+      [
+        "いかないほうがいいです",
+        "you should not go"
+      ],
+      [
+        "たべないほうがいいです",
+        "you should not eat"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜ほうがいい",
+        "〜ほうがいい",
+        "had better ~ / should ~"
+      ],
+      [
+        "〜ほうがいいですよ",
+        "〜ほうがいいですよ",
+        "you should ~, you know"
+      ],
+      [
+        "〜ほうがよかった",
+        "〜ほうがよかった",
+        "would have been better to ~"
+      ],
+      [
+        "アドバイス",
+        "アドバイス",
+        "advice"
+      ],
+      [
+        "おすすめ",
+        "おすすめ",
+        "recommendation"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ほうがいいですよ",
+      "meaning": "You should ~ (advice)",
+      "example_jp": "かぜなら、はやく　ねたほうが　いいですよ",
+      "example_en": "If you have a cold, you should sleep early"
+    },
+    "practice": "Give advice to 5 different situations using ほうがいい.",
+    "tip": "Positive advice: た-form + ほうがいい (did better to ~). Negative advice: ない-form + ほうがいい (not doing better). Both are common advice patterns!"
+  },
+  {
+    "day": 178,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 29,
+    "title": "〜てみる: Try Doing",
+    "intro": "〜てみます = try doing ~. Express attempting something for the first time or experimentally.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべてみます",
+        "try eating"
+      ],
+      [
+        "いってみます",
+        "try going"
+      ],
+      [
+        "はなしてみます",
+        "try speaking"
+      ],
+      [
+        "つかってみます",
+        "try using"
+      ],
+      [
+        "やってみます",
+        "try doing/trying"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜てみてください",
+        "〜てみてください",
+        "please try ~"
+      ],
+      [
+        "〜てみましたか",
+        "〜てみましたか",
+        "have you tried ~?"
+      ],
+      [
+        "〜てみたいです",
+        "〜てみたいです",
+        "want to try ~"
+      ],
+      [
+        "ためしに",
+        "ためしに",
+        "as a trial/experiment"
+      ],
+      [
+        "ちょうせん",
+        "ちょうせん",
+        "challenge"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜てみます",
+      "meaning": "I'll try ~ing",
+      "example_jp": "にほんのたべものを　なんでも　たべてみます",
+      "example_en": "I'll try eating anything Japanese"
+    },
+    "practice": "List 5 things you want to try doing in Japan.",
+    "tip": "〜てみる adds a nuance of 'try and see what happens' — it's experimental and exploratory. Great for expressing curiosity and adventure!"
+  },
+  {
+    "day": 179,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 29,
+    "title": "〜てしまう: Accidentally/Completely",
+    "intro": "〜てしまいます = end up doing ~ (accidentally or completely finished, sometimes regret).",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべてしまいました",
+        "ended up eating (all of it)"
+      ],
+      [
+        "わすれてしまいました",
+        "ended up forgetting"
+      ],
+      [
+        "なくしてしまいました",
+        "ended up losing"
+      ],
+      [
+        "おくれてしまいました",
+        "ended up being late"
+      ],
+      [
+        "いってしまいました",
+        "(they) went away (completely)"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜てしまった",
+        "〜てしまった",
+        "ended up ~ing (plain, with regret)"
+      ],
+      [
+        "〜ちゃった",
+        "〜ちゃった",
+        "ended up ~ing (casual contraction)"
+      ],
+      [
+        "うっかり",
+        "うっかり",
+        "carelessly/accidentally"
+      ],
+      [
+        "のこらず",
+        "のこらず",
+        "without leaving any"
+      ],
+      [
+        "ぜんぶ",
+        "ぜんぶ",
+        "all of it"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜てしまいました",
+      "meaning": "ended up ~ing (accidental/complete)",
+      "example_jp": "さいふを　わすれてしまいました",
+      "example_en": "I ended up forgetting my wallet"
+    },
+    "practice": "Describe 5 accidental things using てしまいました.",
+    "tip": "Casual: 〜てしまった → 〜ちゃった (verbal contraction). わすれてしまった → わすれちゃった. Very common in everyday speech!"
+  },
+  {
+    "day": 180,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 30,
+    "title": "〜させる: Causative",
+    "intro": "〜させます = make/let ~ do ~. Used when someone causes or allows another to do something.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべさせます",
+        "make/let eat"
+      ],
+      [
+        "いかせます",
+        "make/let go"
+      ],
+      [
+        "はなさせます",
+        "make/let speak"
+      ],
+      [
+        "べんきょうさせます",
+        "make/let study"
+      ],
+      [
+        "やすませます",
+        "make/let rest"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜させてください",
+        "〜させてください",
+        "please let me ~"
+      ],
+      [
+        "〜させてもらえますか",
+        "〜させてもらえますか",
+        "may I be allowed to ~?"
+      ],
+      [
+        "むりやり",
+        "むりやり",
+        "by force"
+      ],
+      [
+        "じゆうに",
+        "じゆうに",
+        "freely"
+      ],
+      [
+        "〜させられる",
+        "〜させられる",
+        "be made to ~ (passive causative)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜させてください",
+      "meaning": "Please let me ~",
+      "example_jp": "すこし　かんがえさせてください",
+      "example_en": "Please let me think for a moment"
+    },
+    "practice": "Write: 3 things you want to be allowed to do (させてください) and 3 you'd make others do.",
+    "tip": "させてください is a very polite way to ask permission to do something yourself. More formal than てもいいですか."
+  },
+  {
+    "day": 181,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 30,
+    "title": "〜られる: Passive Form",
+    "intro": "Passive form: RU-verbs: drop る + られる. U-verbs: あ-row + れる.",
+    "type": "verbs",
+    "chars": [
+      [
+        "たべられます",
+        "is eaten / (I) can eat"
+      ],
+      [
+        "みられます",
+        "is seen / (I) can see"
+      ],
+      [
+        "いわれます",
+        "is said / (I) am told"
+      ],
+      [
+        "よばれます",
+        "is called / (I) am called"
+      ],
+      [
+        "しかられます",
+        "is scolded / (I) am scolded"
+      ]
+    ],
+    "vocab": [
+      [
+        "〜にいわれました",
+        "〜にいわれました",
+        "was told by ~"
+      ],
+      [
+        "〜にしかられました",
+        "〜にしかられました",
+        "was scolded by ~"
+      ],
+      [
+        "〜にほめられました",
+        "〜にほめられました",
+        "was praised by ~"
+      ],
+      [
+        "〜によって",
+        "〜によって",
+        "by ~ (passive agent)"
+      ],
+      [
+        "めいわく",
+        "めいわく",
+        "nuisance/trouble"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　〜られました",
+      "meaning": "was ~ed by ~",
+      "example_jp": "せんせいに　ほめられました",
+      "example_en": "I was praised by the teacher"
+    },
+    "practice": "Write 5 passive sentences (something happened to you).",
+    "tip": "Japanese passive is often used for 'suffering passive' — something unpleasant happened TO you: あめにふられた (got rained on). Very common in expressions of inconvenience!"
+  },
+  {
+    "day": 182,
+    "phaseNum": 5,
+    "phaseName": "Verbs",
+    "week": 30,
+    "title": "Verb Phase Final Review",
+    "intro": "Complete review of Phase 5 with JLPT-style practice.",
+    "type": "verbs",
+    "chars": [],
+    "vocab": [
+      [
+        "て-form uses",
+        "て-form uses",
+        "request/sequence/progressive/permission"
+      ],
+      [
+        "たい/ほしい",
+        "たい/ほしい",
+        "want to do / want (thing)"
+      ],
+      [
+        "てもいい/てはいけない",
+        "てもいい/てはいけない",
+        "may/must not"
+      ],
+      [
+        "なければならない/なくてもいい",
+        "なければならない/なくてもいい",
+        "must/don't have to"
+      ],
+      [
+        "たら/ば/と/なら",
+        "たら/ば/と/なら",
+        "4 conditionals"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Phase 5 complete review",
+      "meaning": "All verb forms",
+      "example_jp": "にほんごが　はなせるように　なりたいです。もっとべんきょうしなければなりません",
+      "example_en": "I want to become able to speak Japanese. I must study more"
+    },
+    "practice": "Write a paragraph about your Japanese learning journey using 5+ verb forms from Phase 5.",
+    "tip": "Incredible progress! You've now covered all the major verb patterns for N5 (and beyond). Phase 6 covers the remaining key grammar points!"
+  },
+  {
+    "day": 183,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 27,
+    "title": "〜から: Because",
+    "intro": "から after a plain/polite form = because ~. Gives the reason for something.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜から",
+        "〜から",
+        "because ~ (reason)"
+      ],
+      [
+        "だから",
+        "だから",
+        "therefore / that's why"
+      ],
+      [
+        "なぜなら",
+        "なぜなら",
+        "the reason is that"
+      ],
+      [
+        "〜ので",
+        "〜ので",
+        "because ~ (softer/formal)"
+      ],
+      [
+        "りゆう",
+        "りゆう",
+        "reason"
+      ],
+      [
+        "ぶんぽう",
+        "ぶんぽう",
+        "grammar"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜から",
+      "meaning": "because ~",
+      "example_jp": "あめだから、いえにいます",
+      "example_en": "Because it's raining, I'm home"
+    },
+    "practice": "Write 5 reason sentences: why you like Japanese, why you study, why you are tired.",
+    "tip": "〜から is direct. 〜ので is softer and more formal. In polite writing and formal situations, ので is preferred."
+  },
+  {
+    "day": 184,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 27,
+    "title": "〜ので: Because (Soft)",
+    "intro": "ので is a softer, more polite reason marker than から. Widely used in formal situations.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ので",
+        "〜ので",
+        "because ~ (formal/soft)"
+      ],
+      [
+        "じじょう",
+        "じじょう",
+        "circumstances"
+      ],
+      [
+        "しかたない",
+        "しかたない",
+        "can't be helped"
+      ],
+      [
+        "〜ためです",
+        "〜ためです",
+        "it is because of ~"
+      ],
+      [
+        "もうしわけない",
+        "もうしわけない",
+        "I'm very sorry"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ので、〜ます",
+      "meaning": "Because ~, (I) ~",
+      "example_jp": "ちょっとぐあいがわるいので、きょうはやすみます",
+      "example_en": "Because I'm not feeling well, I'll rest today"
+    },
+    "practice": "Rewrite 5 から sentences as ので sentences. Notice how the tone changes.",
+    "tip": "Rule: plain form + ので (ていねいなので), but な-adj/noun + なので (しずかなので, がくせいなので). Don't use だので!"
+  },
+  {
+    "day": 185,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 27,
+    "title": "〜し: Multiple Reasons",
+    "intro": "〜し = and (listing multiple reasons). More complete than から.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜し、〜し",
+        "〜し、〜し",
+        "not only ~, but also ~ (reasons)"
+      ],
+      [
+        "それに",
+        "それに",
+        "moreover / in addition"
+      ],
+      [
+        "おまけに",
+        "おまけに",
+        "on top of that"
+      ],
+      [
+        "〜うえに",
+        "〜うえに",
+        "in addition to ~"
+      ],
+      [
+        "いろいろと",
+        "いろいろと",
+        "in various ways"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜し、〜し、〜です",
+      "meaning": "not only ~ but also ~, so ~",
+      "example_jp": "にほんごはおもしろいし、たのしいし、べんりです",
+      "example_en": "Japanese is interesting, fun, and useful"
+    },
+    "practice": "List 3 reasons why you like something using 〜し〜し.",
+    "tip": "〜し is perfect for persuasion and listing multiple supporting reasons. Sounds more natural than just stacking から sentences!"
+  },
+  {
+    "day": 186,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 27,
+    "title": "〜が・〜けど: But/However",
+    "intro": "が and けど both mean 'but/however'. が is more formal; けど (keredo) is casual.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜が",
+        "〜が",
+        "but / however (formal)"
+      ],
+      [
+        "〜けど",
+        "〜けど",
+        "but / though (casual)"
+      ],
+      [
+        "〜でも",
+        "〜でも",
+        "but / however (start of sentence)"
+      ],
+      [
+        "〜しかし",
+        "〜しかし",
+        "however (formal)"
+      ],
+      [
+        "〜ところが",
+        "〜ところが",
+        "but (unexpected result)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ですが、〜です",
+      "meaning": "~ but ~",
+      "example_jp": "にほんごはむずかしいですが、おもしろいです",
+      "example_en": "Japanese is difficult, but it's interesting"
+    },
+    "practice": "Write 5 sentences with contrast using が or けど.",
+    "tip": "〜が and 〜けど can also soften requests and lead into an ask: すみませんが、〜してもらえますか (Excuse me, but could you ~?)"
+  },
+  {
+    "day": 187,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 27,
+    "title": "〜のに: Although (Unexpected)",
+    "intro": "のに = although / even though (expresses surprise or disappointment at an unexpected outcome).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜のに",
+        "〜のに",
+        "although ~ / even though ~"
+      ],
+      [
+        "〜にもかかわらず",
+        "〜にもかかわらず",
+        "despite ~ (formal)"
+      ],
+      [
+        "〜はずなのに",
+        "〜はずなのに",
+        "should be ~ but..."
+      ],
+      [
+        "がっかり",
+        "がっかり",
+        "disappointed"
+      ],
+      [
+        "きたいはずれ",
+        "きたいはずれ",
+        "letting down expectations"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜のに、〜ます",
+      "meaning": "although ~, ~ (unexpected)",
+      "example_jp": "べんきょうしたのに、しけんにおちました",
+      "example_en": "Even though I studied, I failed the test"
+    },
+    "practice": "Express 3 disappointments or surprises using のに.",
+    "tip": "のに carries an emotional tone of complaint or surprise. が/けど are neutral contrast; のに has feeling baked in!"
+  },
+  {
+    "day": 188,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 27,
+    "title": "〜でも: Even / But",
+    "intro": "でも = but (sentence-initial). Also: even ~ / at least ~.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "でも",
+        "でも",
+        "but / however (starts sentence)"
+      ],
+      [
+        "〜でも",
+        "〜でも",
+        "even ~ (after noun)"
+      ],
+      [
+        "どんなことでも",
+        "どんなことでも",
+        "anything at all"
+      ],
+      [
+        "だれでも",
+        "だれでも",
+        "anyone at all"
+      ],
+      [
+        "いつでも",
+        "いつでも",
+        "anytime"
+      ]
+    ],
+    "grammar": {
+      "pattern": "でも、〜です",
+      "meaning": "But, ~",
+      "example_jp": "むずかしいです。でも、たのしいです",
+      "example_en": "It's difficult. But it's fun"
+    },
+    "practice": "Write 5 sentences starting with でも to express contrast.",
+    "tip": "〜でも (attached to word) = 'even': だれでも = anyone, なんでも = anything, どこでも = anywhere. Very useful for inclusive expressions!"
+  },
+  {
+    "day": 189,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 27,
+    "title": "〜ましょう・〜ませんか: Suggestions",
+    "intro": "〜ましょう = Let's ~. 〜ませんか = Shall we ~? / Won't you ~?",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ましょう",
+        "〜ましょう",
+        "let's ~ (invitation/proposal)"
+      ],
+      [
+        "〜ましょうか",
+        "〜ましょうか",
+        "shall I / shall we ~?"
+      ],
+      [
+        "〜ませんか",
+        "〜ませんか",
+        "won't you ~? / how about ~?"
+      ],
+      [
+        "さそう",
+        "さそう",
+        "invite"
+      ],
+      [
+        "ていあん",
+        "ていあん",
+        "suggestion/proposal"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ましょう / 〜ませんか",
+      "meaning": "Let's ~ / Shall we ~?",
+      "example_jp": "いっしょに　ひるごはんを　たべませんか",
+      "example_en": "Won't you eat lunch with me?"
+    },
+    "practice": "Invite someone to: eat lunch, study Japanese, watch a movie, go shopping, take a walk.",
+    "tip": "ましょう is more assertive (Let's go!). ませんか is softer and more polite (Wouldn't you like to go?). Japanese culture tends to prefer the softer option!"
+  },
+  {
+    "day": 190,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 28,
+    "title": "〜てほしい: Want Someone Else to Do",
+    "intro": "〜てほしいです = I want (someone else) to ~. Different from たい (MY desire).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜てほしい",
+        "〜てほしい",
+        "want (them) to ~"
+      ],
+      [
+        "〜てほしくない",
+        "〜てほしくない",
+        "don't want (them) to ~"
+      ],
+      [
+        "〜てほしかった",
+        "〜てほしかった",
+        "wanted (them) to ~"
+      ],
+      [
+        "おねがい",
+        "おねがい",
+        "please / request"
+      ],
+      [
+        "きたい",
+        "きたい",
+        "expectation"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜に　〜てほしいです",
+      "meaning": "I want ~ to ~",
+      "example_jp": "せんせいに　もっと　ゆっくり　はなしてほしいです",
+      "example_en": "I want the teacher to speak more slowly"
+    },
+    "practice": "Write 5 things you want others to do for you using てほしい.",
+    "tip": "たい = I want to do ~ (my desire). てほしい = I want someone else to do ~ (desire about others' actions). Critical distinction!"
+  },
+  {
+    "day": 191,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 28,
+    "title": "〜とき: When (Time)",
+    "intro": "〜とき = when / at the time of ~. Marks a specific time or condition.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜とき",
+        "〜とき",
+        "when ~ / at the time of ~"
+      ],
+      [
+        "こどものとき",
+        "こどものとき",
+        "when I was a child"
+      ],
+      [
+        "べんきょうするとき",
+        "べんきょうするとき",
+        "when studying"
+      ],
+      [
+        "こまったとき",
+        "こまったとき",
+        "when in trouble"
+      ],
+      [
+        "〜ときに",
+        "〜ときに",
+        "at the time when ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜とき、〜ます",
+      "meaning": "When ~, (I) ~",
+      "example_jp": "にほんにいくとき、にほんごではなしたいです",
+      "example_en": "When I go to Japan, I want to speak in Japanese"
+    },
+    "practice": "Write 5 sentences using とき: childhood memories, daily habits, future plans.",
+    "tip": "とき vs たら: とき = 'at the time when' (describes circumstances). たら = 'when/if' (conditional, triggers next action). Subtle but important!"
+  },
+  {
+    "day": 192,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 28,
+    "title": "〜ために: In Order To / For",
+    "intro": "〜ために = in order to ~ / for the sake of ~.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ために",
+        "〜ために",
+        "in order to ~ / for the sake of ~"
+      ],
+      [
+        "もくてき",
+        "もくてき",
+        "purpose/goal"
+      ],
+      [
+        "〜のために",
+        "〜のために",
+        "for the sake of ~"
+      ],
+      [
+        "〜ようにするために",
+        "〜ようにするために",
+        "in order to be able to ~"
+      ],
+      [
+        "どりょく",
+        "どりょく",
+        "effort"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ために、〜ます",
+      "meaning": "In order to ~, (I) ~",
+      "example_jp": "にほんごをはなせるようになるために、まいにちべんきょうします",
+      "example_en": "In order to be able to speak Japanese, I study every day"
+    },
+    "practice": "Write your top 3 life goals and what you do each day to achieve them using ために.",
+    "tip": "〜ために expresses PURPOSE. 〜から/ので expresses REASON. Distinction: ために looks forward (goal), から/ので looks backward (cause)."
+  },
+  {
+    "day": 193,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 28,
+    "title": "〜ように: So That / In Order To",
+    "intro": "〜ようにします = make sure to ~, try to ~. 〜ようになります = come to be able to ~.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ようになりました",
+        "〜ようになりました",
+        "came to be able to ~ (gradual change)"
+      ],
+      [
+        "〜ようにしています",
+        "〜ようにしています",
+        "I make a point of ~ing"
+      ],
+      [
+        "〜できるようになる",
+        "〜できるようになる",
+        "become able to ~"
+      ],
+      [
+        "〜ないようにする",
+        "〜ないようにする",
+        "try not to ~"
+      ],
+      [
+        "せいちょう",
+        "せいちょう",
+        "growth"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ように　なりました",
+      "meaning": "came to be able to ~",
+      "example_jp": "にほんごで　はなせるように　なりました",
+      "example_en": "I've come to be able to speak in Japanese"
+    },
+    "practice": "Write 3 things you've come to be able to do (ようになりました) since starting to study Japanese.",
+    "tip": "〜ようになる expresses GRADUAL CHANGE — perfect for describing learning progress! This is a great pattern to use in your journal."
+  },
+  {
+    "day": 194,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 28,
+    "title": "〜という: Called / Named",
+    "intro": "〜という = called ~ / that ~ (quoting or naming).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜という",
+        "〜という",
+        "called ~ / named ~"
+      ],
+      [
+        "〜ということ",
+        "〜ということ",
+        "the fact that ~"
+      ],
+      [
+        "〜という　こと",
+        "〜という　こと",
+        "the thing called ~"
+      ],
+      [
+        "〜とは",
+        "〜とは",
+        "what is ~? / as for ~"
+      ],
+      [
+        "〜の　いみ",
+        "〜の　いみ",
+        "the meaning of ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜という　Noun",
+      "meaning": "a Noun called ~",
+      "example_jp": "「さくら」という　ことばを　しっていますか",
+      "example_en": "Do you know the word called 'sakura'?"
+    },
+    "practice": "Use 〜という to explain Japanese words or concepts you've learned.",
+    "tip": "〜という is extremely useful for talking about Japanese words and culture: 〜というのはどういう意味ですか (What does ~ mean?)"
+  },
+  {
+    "day": 195,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 28,
+    "title": "〜のは・〜のが・〜のを: Nominaliser の",
+    "intro": "の turns verb phrases into nouns (nominaliser).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜のは　〜です",
+        "〜のは　〜です",
+        "The ~ of doing ~ is ~"
+      ],
+      [
+        "〜のが　すき",
+        "〜のが　すき",
+        "like ~ing"
+      ],
+      [
+        "〜のが　とくい",
+        "〜のが　とくい",
+        "good at ~ing"
+      ],
+      [
+        "〜のを　みた",
+        "〜のを　みた",
+        "saw ~ doing ~"
+      ],
+      [
+        "〜のが　わかる",
+        "〜のが　わかる",
+        "understand that ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜のが　すきです",
+      "meaning": "I like ~ing",
+      "example_jp": "にほんごをべんきょうするのが　すきです",
+      "example_en": "I like studying Japanese"
+    },
+    "practice": "Write: 3 things you like doing, 3 things you're good at, using のがすき/とくい.",
+    "tip": "の nominaliser vs こと nominaliser: のが is used with perception verbs (みる、きく) and likes. こと is used with ことができる, knowing facts, etc. Both are needed!"
+  },
+  {
+    "day": 196,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 28,
+    "title": "〜ようだ・〜みたいだ: Seems Like",
+    "intro": "〜ようです = it seems that ~ (formal). 〜みたいです = seems like ~ (casual).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ようです",
+        "〜ようです",
+        "it seems that ~ (formal)"
+      ],
+      [
+        "〜みたいです",
+        "〜みたいです",
+        "seems like ~ (casual)"
+      ],
+      [
+        "〜らしいです",
+        "〜らしいです",
+        "apparently ~ / I heard ~"
+      ],
+      [
+        "〜そうです",
+        "〜そうです",
+        "looks like / I heard"
+      ],
+      [
+        "〜かもしれません",
+        "〜かもしれません",
+        "might be ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜みたいです / 〜ようです",
+      "meaning": "seems like / it appears that",
+      "example_jp": "かれは　にほんじんみたいです",
+      "example_en": "He seems to be Japanese"
+    },
+    "practice": "Write 5 observations using みたいです and ようです about things you notice around you.",
+    "tip": "The spectrum from certain to uncertain: です (certain) → ようです/みたいです (seems) → でしょう (probably) → かもしれません (might) → はずがない (can't be)"
+  },
+  {
+    "day": 197,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 29,
+    "title": "〜はずです: Should Be / Expected",
+    "intro": "〜はずです = should be ~ / expected to ~. Based on reasoning or expectation.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜はずです",
+        "〜はずです",
+        "should be ~ / expected to ~"
+      ],
+      [
+        "〜はずがありません",
+        "〜はずがありません",
+        "can't possibly be ~"
+      ],
+      [
+        "〜はずだった",
+        "〜はずだった",
+        "was supposed to ~"
+      ],
+      [
+        "よてい",
+        "よてい",
+        "plan/schedule"
+      ],
+      [
+        "みこみ",
+        "みこみ",
+        "expectation/hope"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜はずです",
+      "meaning": "should be ~ (based on expectation)",
+      "example_jp": "かれは　もうすぐ　くるはずです",
+      "example_en": "He should be coming soon"
+    },
+    "practice": "Write 5 expectations using はずです — what should happen today/this week?",
+    "tip": "はずだった (was supposed to ~) expresses disappointment when things didn't go as expected: くるはずだったのに、こなかった (Was supposed to come but didn't)"
+  },
+  {
+    "day": 198,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 29,
+    "title": "〜かどうか: Whether or Not",
+    "intro": "〜かどうか = whether or not ~. Used with embedded questions.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜かどうかわかりません",
+        "〜かどうかわかりません",
+        "I don't know whether ~"
+      ],
+      [
+        "〜かどうかきいてみます",
+        "〜かどうかきいてみます",
+        "I'll ask whether ~"
+      ],
+      [
+        "〜かどうかかんがえています",
+        "〜かどうかかんがえています",
+        "I'm thinking about whether ~"
+      ],
+      [
+        "はんだん",
+        "はんだん",
+        "judgment/decision"
+      ],
+      [
+        "けってい",
+        "けってい",
+        "decision"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜かどうか、わかりません",
+      "meaning": "I don't know whether ~",
+      "example_jp": "あしたあめがふるかどうか、わかりません",
+      "example_en": "I don't know whether it will rain tomorrow"
+    },
+    "practice": "Write 5 uncertainties using かどうか.",
+    "tip": "〜かどうか embeds a yes/no question into another sentence. 〜かを embeds a wh-question: どこにいったか (where they went). Both essential for indirect speech!"
+  },
+  {
+    "day": 199,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 29,
+    "title": "〜まま: As Is / Unchanged State",
+    "intro": "〜まま = as is / in that state (unchanged). Describes maintaining a state.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜たまま",
+        "〜たまま",
+        "while still ~ / having done ~ and staying that way"
+      ],
+      [
+        "〜ないまま",
+        "〜ないまま",
+        "without ~ing / staying in un-~ed state"
+      ],
+      [
+        "そのまま",
+        "そのまま",
+        "as is / just like that"
+      ],
+      [
+        "〜つづける",
+        "〜つづける",
+        "continue to ~"
+      ],
+      [
+        "かわらず",
+        "かわらず",
+        "unchanged"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜たまま",
+      "meaning": "still ~ / having done ~ and left it that way",
+      "example_jp": "くつを　はいたまま　はいってしまいました",
+      "example_en": "I entered while still wearing my shoes"
+    },
+    "practice": "Write 3 まま sentences about states that were left unchanged.",
+    "tip": "〜まま: めをとじたまま (with eyes still closed), くつをはいたまま (with shoes still on). Describes not changing a state — very natural in Japanese!"
+  },
+  {
+    "day": 200,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 29,
+    "title": "Grammar Checkpoint: Days 183-199",
+    "intro": "Review of all grammar from the last 17 days.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜から・ので",
+        "〜から・ので",
+        "because"
+      ],
+      [
+        "〜が・けど",
+        "〜が・けど",
+        "but"
+      ],
+      [
+        "〜ために",
+        "〜ために",
+        "in order to"
+      ],
+      [
+        "〜ように",
+        "〜ように",
+        "so that/come to"
+      ],
+      [
+        "〜はずです",
+        "〜はずです",
+        "should be"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review: reason, contrast, purpose",
+      "meaning": "Core linking grammar",
+      "example_jp": "にほんごがはなせるようになるために、まいにちべんきょうしています。むずかしいですが、たのしいです",
+      "example_en": "I study every day to be able to speak Japanese. It's difficult, but fun"
+    },
+    "practice": "Write a paragraph about your Japanese study using at least 5 grammar patterns from days 183-199.",
+    "tip": "Midpoint of Phase 6! You're building the connective tissue of Japanese — the grammar that links ideas into natural, flowing speech."
+  },
+  {
+    "day": 201,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 29,
+    "title": "〜ていただけますか: Very Polite Request",
+    "intro": "The most polite way to request — for formal settings and seniors.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ていただけますか",
+        "〜ていただけますか",
+        "would you kindly ~?"
+      ],
+      [
+        "〜てくださいませんか",
+        "〜てくださいませんか",
+        "would you please ~?"
+      ],
+      [
+        "〜てもらえますか",
+        "〜てもらえますか",
+        "would you do ~ for me?"
+      ],
+      [
+        "ていねいご",
+        "ていねいご",
+        "polite language"
+      ],
+      [
+        "けいご",
+        "けいご",
+        "honorific language"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ていただけますか",
+      "meaning": "Would you kindly ~?",
+      "example_jp": "もういちど　おっしゃっていただけますか",
+      "example_en": "Would you kindly say that again?"
+    },
+    "practice": "Write 5 very polite requests for hotel, hospital, office situations.",
+    "tip": "Politeness ladder: してください < してもらえますか < していただけますか. Use the last for seniors and formal occasions!"
+  },
+  {
+    "day": 202,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 29,
+    "title": "〜ようにしてください: Please Make Sure",
+    "intro": "Please make sure to ~. Stronger than just ください.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ようにしてください",
+        "〜ようにしてください",
+        "please make sure to ~"
+      ],
+      [
+        "〜ないようにしてください",
+        "〜ないようにしてください",
+        "please make sure not to ~"
+      ],
+      [
+        "きをつける",
+        "きをつける",
+        "be careful"
+      ],
+      [
+        "まもる",
+        "まもる",
+        "follow rules"
+      ],
+      [
+        "こころがける",
+        "こころがける",
+        "keep in mind"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ように　してください",
+      "meaning": "Please make sure to ~",
+      "example_jp": "まいにち　くすりを　のむように　してください",
+      "example_en": "Please make sure to take your medicine every day"
+    },
+    "practice": "Write 5 careful instructions using ようにしてください.",
+    "tip": "〜ようにする (make a point of) vs 〜ようになる (come to be able to). Both essential patterns for expressing habits and changes!"
+  },
+  {
+    "day": 203,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 29,
+    "title": "〜までに: By (Deadline)",
+    "intro": "〜まで = until. 〜までに = by (deadline). Critical distinction!",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜まで",
+        "〜まで",
+        "until ~"
+      ],
+      [
+        "〜までに",
+        "〜までに",
+        "by ~ (deadline)"
+      ],
+      [
+        "しめきり",
+        "しめきり",
+        "deadline"
+      ],
+      [
+        "きげん",
+        "きげん",
+        "time limit"
+      ],
+      [
+        "かんりょう",
+        "かんりょう",
+        "completion"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜までに　〜ます",
+      "meaning": "will ~ by ~",
+      "example_jp": "かようびまでに　しゅくだいを　だします",
+      "example_en": "I will submit homework by Tuesday"
+    },
+    "practice": "Write 5 deadline sentences: what will you do by when?",
+    "tip": "まで = duration (until 5 o'clock). までに = deadline (by 5 o'clock). One particle changes the meaning entirely!"
+  },
+  {
+    "day": 204,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 30,
+    "title": "〜たばかりです: Just Did",
+    "intro": "〜たばかり = just completed an action (very recently).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜たばかりです",
+        "〜たばかりです",
+        "just ~ed"
+      ],
+      [
+        "ちょうど",
+        "ちょうど",
+        "just now / exactly"
+      ],
+      [
+        "さっき",
+        "さっき",
+        "a moment ago"
+      ],
+      [
+        "〜したところです",
+        "〜したところです",
+        "just finished doing"
+      ],
+      [
+        "まだ〜ていません",
+        "まだ〜ていません",
+        "haven't done yet"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜たばかりです",
+      "meaning": "just ~ed",
+      "example_jp": "にほんに　きたばかりです",
+      "example_en": "I just arrived in Japan"
+    },
+    "practice": "Write 5 'just did' sentences using たばかりです.",
+    "tip": "たばかり = very recently completed. Perfect for first encounters: にほんごをべんきょうしはじめたばかりです (I just started studying Japanese)!"
+  },
+  {
+    "day": 205,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 30,
+    "title": "〜だけ vs 〜しか〜ない: Only",
+    "intro": "だけ = only (neutral). しか〜ない = only/nothing but (emphatic, with negative).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜だけです",
+        "〜だけです",
+        "only ~ (neutral)"
+      ],
+      [
+        "〜しか〜ない",
+        "〜しか〜ない",
+        "only ~ (emphatic negative)"
+      ],
+      [
+        "それだけ",
+        "それだけ",
+        "that's all"
+      ],
+      [
+        "〜のみ",
+        "〜のみ",
+        "only (formal)"
+      ],
+      [
+        "ほかには",
+        "ほかには",
+        "other than that"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜だけ / 〜しか〜ない",
+      "meaning": "only ~ (neutral/emphatic)",
+      "example_jp": "みずだけのみます。/みずしかありません",
+      "example_en": "I'll only drink water. / There's only water (nothing else)"
+    },
+    "practice": "Write 5 sentences with だけ and 5 with しか〜ない, noting the difference in nuance.",
+    "tip": "KEY: しか ALWAYS takes negative verb: 〜しか〜ない. The emphasis is built into the negative: there's ONLY this, NOTHING else!"
+  },
+  {
+    "day": 206,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 30,
+    "title": "〜も: Quantity Emphasis",
+    "intro": "も after numbers = 'as many as'. も with negation = 'not even'.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜もあります",
+        "〜もあります",
+        "there are as many as ~"
+      ],
+      [
+        "ひとつもない",
+        "ひとつもない",
+        "not even one"
+      ],
+      [
+        "だれも〜ない",
+        "だれも〜ない",
+        "nobody at all"
+      ],
+      [
+        "なにも〜ない",
+        "なにも〜ない",
+        "nothing at all"
+      ],
+      [
+        "どこも〜ない",
+        "どこも〜ない",
+        "nowhere at all"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜も　〜ません",
+      "meaning": "not even ~ (emphasis)",
+      "example_jp": "ひとつも　わかりません",
+      "example_en": "I don't understand even one thing"
+    },
+    "practice": "Write 3 'surprising amounts' and 3 'complete negation' sentences using も.",
+    "tip": "Total negation family: だれも〜ない, なにも〜ない, どこも〜ない, いつも〜ない. Learn them together as a set!"
+  },
+  {
+    "day": 207,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 30,
+    "title": "〜ごろ・くらい・ほど: Approximation",
+    "intro": "ごろ = around (time). くらい/ほど = approximately (amount, degree).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ごろ",
+        "〜ごろ",
+        "around ~ (time only)"
+      ],
+      [
+        "〜くらい",
+        "〜くらい",
+        "about ~ (amount, casual)"
+      ],
+      [
+        "〜ほど",
+        "〜ほど",
+        "about ~ (formal, extent)"
+      ],
+      [
+        "だいたい",
+        "だいたい",
+        "approximately"
+      ],
+      [
+        "〜ぐらい",
+        "〜ぐらい",
+        "about ~ (variant of くらい)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ごろ / 〜くらい",
+      "meaning": "around ~ / approximately ~",
+      "example_jp": "さんじごろに　きます。いちじかんくらいかかります",
+      "example_en": "I'll come around 3. It takes about 1 hour"
+    },
+    "practice": "Write 5 approximate expressions: times with ごろ, amounts with くらい.",
+    "tip": "ごろ is for TIME only. くらい/ほど are for AMOUNTS, DISTANCES, and EXTENTS. Mixing them is a common mistake!"
+  },
+  {
+    "day": 208,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "〜おかげで: Thanks to (Positive)",
+    "intro": "〜おかげで = thanks to ~ (used when the result is POSITIVE).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜おかげで",
+        "〜おかげで",
+        "thanks to ~"
+      ],
+      [
+        "おかげさまで",
+        "おかげさまで",
+        "thanks to you / thanks to everyone"
+      ],
+      [
+        "〜のおかげ",
+        "〜のおかげ",
+        "owing to ~"
+      ],
+      [
+        "かんしゃ",
+        "かんしゃ",
+        "gratitude"
+      ],
+      [
+        "おせわになりました",
+        "おせわになりました",
+        "thank you for your care/help"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜おかげで、〜できました",
+      "meaning": "Thanks to ~, I was able to ~",
+      "example_jp": "みなさんの　おかげで　ごうかくしました",
+      "example_en": "Thanks to everyone, I passed"
+    },
+    "practice": "Write 3 things you're grateful for using おかげで.",
+    "tip": "おかげで = good result. せいで = bad result. Always match the cause word to the outcome tone: positive → おかげで, negative → せいで!"
+  },
+  {
+    "day": 209,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "〜せいで: Because of (Negative)",
+    "intro": "〜せいで = because of ~ (leading to a BAD result).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜せいで",
+        "〜せいで",
+        "because of ~ (bad)"
+      ],
+      [
+        "〜のせいにする",
+        "〜のせいにする",
+        "blame ~ for"
+      ],
+      [
+        "せきにん",
+        "せきにん",
+        "responsibility"
+      ],
+      [
+        "もんく",
+        "もんく",
+        "complaint"
+      ],
+      [
+        "あやまる",
+        "あやまる",
+        "apologise"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜のせいで、〜なりました",
+      "meaning": "Because of ~, ~ happened (bad)",
+      "example_jp": "かれの　せいで　おくれました",
+      "example_en": "Because of him, I was late"
+    },
+    "practice": "Write 3 sentences expressing blame or negative outcomes using せいで.",
+    "tip": "おかげで (positive result) vs せいで (negative result). Choosing the wrong one is a significant social mistake — be careful!"
+  },
+  {
+    "day": 210,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "〜ことにする vs 〜ことになる",
+    "intro": "ことにする = I decided. ことになる = it has been decided (external decision).",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜ことにしました",
+        "〜ことにしました",
+        "I decided to ~"
+      ],
+      [
+        "〜ことになりました",
+        "〜ことになりました",
+        "it has been decided that ~ (external)"
+      ],
+      [
+        "〜ことにしています",
+        "〜ことにしています",
+        "I have a policy of ~"
+      ],
+      [
+        "けつだん",
+        "けつだん",
+        "decision"
+      ],
+      [
+        "さだめられた",
+        "さだめられた",
+        "determined/fixed"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜ことにした / 〜ことになった",
+      "meaning": "decided (self) / was decided (external)",
+      "example_jp": "にほんにいくことにしました。来年日本に行くことになりました",
+      "example_en": "I decided to go to Japan. / It was decided I'll go to Japan next year"
+    },
+    "practice": "Write 3 personal decisions (ことにした) and 3 external decisions (ことになった).",
+    "tip": "ことにした = YOUR active choice. ことになった = the situation/others decided. Very common in Japanese work settings!"
+  },
+  {
+    "day": 211,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "〜といえば: Speaking of",
+    "intro": "といえば = speaking of ~, when it comes to ~.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "〜といえば",
+        "〜といえば",
+        "speaking of ~"
+      ],
+      [
+        "〜といったら",
+        "〜といったら",
+        "when it comes to ~"
+      ],
+      [
+        "〜で　いえば",
+        "〜で　いえば",
+        "in terms of ~"
+      ],
+      [
+        "だいひょうてき",
+        "だいひょうてき",
+        "representative"
+      ],
+      [
+        "〜の　シンボル",
+        "〜の　シンボル",
+        "symbol of ~"
+      ]
+    ],
+    "grammar": {
+      "pattern": "〜といえば",
+      "meaning": "speaking of ~ / when it comes to ~",
+      "example_jp": "にほんといえば、さくらですね",
+      "example_en": "When it comes to Japan, it's cherry blossoms"
+    },
+    "practice": "Use といえば to free-associate: what comes to mind when you think of Japan, food, seasons?",
+    "tip": "〜といえば triggers a topic association. Very common in conversation: A mentions something, B says といえば and brings up related topic. Natural and friendly!"
+  },
+  {
+    "day": 212,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "Grammar & JLPT Practice: Day 29",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 213,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "Grammar & JLPT Practice: Day 30",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 214,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "Grammar & JLPT Practice: Day 31",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 215,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "Grammar & JLPT Practice: Day 32",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 216,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "Grammar & JLPT Practice: Day 33",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 217,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 31,
+    "title": "Grammar & JLPT Practice: Day 34",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 218,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 32,
+    "title": "Grammar & JLPT Practice: Day 35",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 219,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 32,
+    "title": "Grammar & JLPT Practice: Day 36",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 220,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 32,
+    "title": "Grammar & JLPT Practice: Day 37",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 221,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 32,
+    "title": "Grammar & JLPT Practice: Day 38",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 222,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 32,
+    "title": "Grammar & JLPT Practice: Day 39",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 223,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 32,
+    "title": "Grammar & JLPT Practice: Day 40",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 224,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 32,
+    "title": "Grammar & JLPT Practice: Day 41",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 225,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 33,
+    "title": "Grammar & JLPT Practice: Day 42",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 226,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 33,
+    "title": "Grammar & JLPT Practice: Day 43",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 227,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 33,
+    "title": "Grammar & JLPT Practice: Day 44",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 228,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 33,
+    "title": "Grammar & JLPT Practice: Day 45",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 229,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 33,
+    "title": "Grammar & JLPT Practice: Day 46",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 230,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 33,
+    "title": "Grammar & JLPT Practice: Day 47",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 231,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 33,
+    "title": "Grammar & JLPT Practice: Day 48",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 232,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 34,
+    "title": "Grammar & JLPT Practice: Day 49",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 233,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 34,
+    "title": "Grammar & JLPT Practice: Day 50",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 234,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 34,
+    "title": "Grammar & JLPT Practice: Day 51",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 235,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 34,
+    "title": "Grammar & JLPT Practice: Day 52",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 236,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 34,
+    "title": "Grammar & JLPT Practice: Day 53",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 237,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 34,
+    "title": "Grammar & JLPT Practice: Day 54",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 238,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 34,
+    "title": "Grammar & JLPT Practice: Day 55",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 239,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 35,
+    "title": "Grammar & JLPT Practice: Day 56",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 240,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 35,
+    "title": "Grammar & JLPT Practice: Day 57",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 241,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 35,
+    "title": "Grammar & JLPT Practice: Day 58",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 242,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 35,
+    "title": "Grammar & JLPT Practice: Day 59",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 243,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 35,
+    "title": "Grammar & JLPT Practice: Day 60",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 244,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 35,
+    "title": "Grammar & JLPT Practice: Day 61",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 245,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 35,
+    "title": "Grammar & JLPT Practice: Day 62",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 246,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 36,
+    "title": "Grammar & JLPT Practice: Day 63",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 247,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 36,
+    "title": "Grammar & JLPT Practice: Day 64",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 248,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 36,
+    "title": "Grammar & JLPT Practice: Day 65",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 249,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 36,
+    "title": "Grammar & JLPT Practice: Day 66",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 250,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 36,
+    "title": "Grammar & JLPT Practice: Day 67",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 251,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 36,
+    "title": "Grammar & JLPT Practice: Day 68",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 252,
+    "phaseNum": 6,
+    "phaseName": "Grammar",
+    "week": 36,
+    "title": "Grammar & JLPT Practice: Day 69",
+    "intro": "Daily grammar review with JLPT N5 style practice exercises.",
+    "type": "grammar",
+    "chars": [],
+    "vocab": [
+      [
+        "もんだい1",
+        "もんだい1",
+        "practice question 1"
+      ],
+      [
+        "もんだい2",
+        "もんだい2",
+        "practice question 2"
+      ],
+      [
+        "もんだい3",
+        "もんだい3",
+        "practice question 3"
+      ],
+      [
+        "もんだい4",
+        "もんだい4",
+        "practice question 4"
+      ],
+      [
+        "もんだい5",
+        "もんだい5",
+        "practice question 5"
+      ]
+    ],
+    "grammar": {
+      "pattern": "JLPT N5 Grammar Practice",
+      "meaning": "Multiple choice and fill-in",
+      "example_jp": "もんだいを　といて、まちがいを　なおしましょう",
+      "example_en": "Solve the questions and correct your mistakes"
+    },
+    "practice": "Complete 10 JLPT-style grammar questions. Review any wrong answers carefully.",
+    "tip": "Regular JLPT practice trains both grammar knowledge AND test-taking strategy. Both matter on exam day!"
+  },
+  {
+    "day": 253,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 37,
+    "title": "Kanji: 一 (one)",
+    "intro": "Today's kanji: 一. Readings: ichi/hito. Meaning: one.",
+    "type": "kanji",
+    "chars": [
+      [
+        "一",
+        "ichi/hito"
+      ]
+    ],
+    "vocab": [
+      [
+        "一",
+        "ichi/hito",
+        "one"
+      ],
+      [
+        "いちにち",
+        "いちにち",
+        "いちにち=1 day, ひとり=1 person"
+      ]
+    ],
+    "grammar": {
+      "pattern": "一 in words",
+      "meaning": "one",
+      "example_jp": "いちにち=1 day",
+      "example_en": "one"
+    },
+    "practice": "Write 一 20 times. Learn: いちにち=1 day, ひとり=1 person",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 一 and practice carefully!"
+  },
+  {
+    "day": 254,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 37,
+    "title": "Kanji: 二 (two)",
+    "intro": "Today's kanji: 二. Readings: ni/futa. Meaning: two.",
+    "type": "kanji",
+    "chars": [
+      [
+        "二",
+        "ni/futa"
+      ]
+    ],
+    "vocab": [
+      [
+        "二",
+        "ni/futa",
+        "two"
+      ],
+      [
+        "にほん",
+        "にほん",
+        "にほん=Japan, ふたつ=2 things"
+      ]
+    ],
+    "grammar": {
+      "pattern": "二 in words",
+      "meaning": "two",
+      "example_jp": "にほん=Japan",
+      "example_en": "two"
+    },
+    "practice": "Write 二 20 times. Learn: にほん=Japan, ふたつ=2 things",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 二 and practice carefully!"
+  },
+  {
+    "day": 255,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 37,
+    "title": "Kanji: 三 (three)",
+    "intro": "Today's kanji: 三. Readings: san/mit. Meaning: three.",
+    "type": "kanji",
+    "chars": [
+      [
+        "三",
+        "san/mit"
+      ]
+    ],
+    "vocab": [
+      [
+        "三",
+        "san/mit",
+        "three"
+      ],
+      [
+        "さんにん",
+        "さんにん",
+        "さんにん=3 people"
+      ]
+    ],
+    "grammar": {
+      "pattern": "三 in words",
+      "meaning": "three",
+      "example_jp": "さんにん=3 people",
+      "example_en": "three"
+    },
+    "practice": "Write 三 20 times. Learn: さんにん=3 people",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 三 and practice carefully!"
+  },
+  {
+    "day": 256,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 37,
+    "title": "Kanji: 四 (four)",
+    "intro": "Today's kanji: 四. Readings: shi/yon/yot. Meaning: four.",
+    "type": "kanji",
+    "chars": [
+      [
+        "四",
+        "shi/yon/yot"
+      ]
+    ],
+    "vocab": [
+      [
+        "四",
+        "shi/yon/yot",
+        "four"
+      ],
+      [
+        "よじ",
+        "よじ",
+        "よじ=4 o'clock, しがつ=April"
+      ]
+    ],
+    "grammar": {
+      "pattern": "四 in words",
+      "meaning": "four",
+      "example_jp": "よじ=4 o'clock",
+      "example_en": "four"
+    },
+    "practice": "Write 四 20 times. Learn: よじ=4 o'clock, しがつ=April",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 四 and practice carefully!"
+  },
+  {
+    "day": 257,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 37,
+    "title": "Kanji: 五 (five)",
+    "intro": "Today's kanji: 五. Readings: go/itsu. Meaning: five.",
+    "type": "kanji",
+    "chars": [
+      [
+        "五",
+        "go/itsu"
+      ]
+    ],
+    "vocab": [
+      [
+        "五",
+        "go/itsu",
+        "five"
+      ],
+      [
+        "ごにん",
+        "ごにん",
+        "ごにん=5 people"
+      ]
+    ],
+    "grammar": {
+      "pattern": "五 in words",
+      "meaning": "five",
+      "example_jp": "ごにん=5 people",
+      "example_en": "five"
+    },
+    "practice": "Write 五 20 times. Learn: ごにん=5 people",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 五 and practice carefully!"
+  },
+  {
+    "day": 258,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 37,
+    "title": "Kanji: 六 (six)",
+    "intro": "Today's kanji: 六. Readings: roku/mut. Meaning: six.",
+    "type": "kanji",
+    "chars": [
+      [
+        "六",
+        "roku/mut"
+      ]
+    ],
+    "vocab": [
+      [
+        "六",
+        "roku/mut",
+        "six"
+      ],
+      [
+        "ろくじ",
+        "ろくじ",
+        "ろくじ=6 o'clock"
+      ]
+    ],
+    "grammar": {
+      "pattern": "六 in words",
+      "meaning": "six",
+      "example_jp": "ろくじ=6 o'clock",
+      "example_en": "six"
+    },
+    "practice": "Write 六 20 times. Learn: ろくじ=6 o'clock",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 六 and practice carefully!"
+  },
+  {
+    "day": 259,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 37,
+    "title": "Kanji: 七 (seven)",
+    "intro": "Today's kanji: 七. Readings: shichi/nana. Meaning: seven.",
+    "type": "kanji",
+    "chars": [
+      [
+        "七",
+        "shichi/nana"
+      ]
+    ],
+    "vocab": [
+      [
+        "七",
+        "shichi/nana",
+        "seven"
+      ],
+      [
+        "しちじ",
+        "しちじ",
+        "しちじ=7 o'clock"
+      ]
+    ],
+    "grammar": {
+      "pattern": "七 in words",
+      "meaning": "seven",
+      "example_jp": "しちじ=7 o'clock",
+      "example_en": "seven"
+    },
+    "practice": "Write 七 20 times. Learn: しちじ=7 o'clock",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 七 and practice carefully!"
+  },
+  {
+    "day": 260,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 38,
+    "title": "Kanji: 八 (eight)",
+    "intro": "Today's kanji: 八. Readings: hachi/yat. Meaning: eight.",
+    "type": "kanji",
+    "chars": [
+      [
+        "八",
+        "hachi/yat"
+      ]
+    ],
+    "vocab": [
+      [
+        "八",
+        "hachi/yat",
+        "eight"
+      ],
+      [
+        "はちじ",
+        "はちじ",
+        "はちじ=8 o'clock"
+      ]
+    ],
+    "grammar": {
+      "pattern": "八 in words",
+      "meaning": "eight",
+      "example_jp": "はちじ=8 o'clock",
+      "example_en": "eight"
+    },
+    "practice": "Write 八 20 times. Learn: はちじ=8 o'clock",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 八 and practice carefully!"
+  },
+  {
+    "day": 261,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 38,
+    "title": "Kanji: 九 (nine)",
+    "intro": "Today's kanji: 九. Readings: ku/kyuu/kokon. Meaning: nine.",
+    "type": "kanji",
+    "chars": [
+      [
+        "九",
+        "ku/kyuu/kokon"
+      ]
+    ],
+    "vocab": [
+      [
+        "九",
+        "ku/kyuu/kokon",
+        "nine"
+      ],
+      [
+        "くじ",
+        "くじ",
+        "くじ=9 o'clock, きゅうにん=9 people"
+      ]
+    ],
+    "grammar": {
+      "pattern": "九 in words",
+      "meaning": "nine",
+      "example_jp": "くじ=9 o'clock",
+      "example_en": "nine"
+    },
+    "practice": "Write 九 20 times. Learn: くじ=9 o'clock, きゅうにん=9 people",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 九 and practice carefully!"
+  },
+  {
+    "day": 262,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 38,
+    "title": "Kanji: 十 (ten)",
+    "intro": "Today's kanji: 十. Readings: juu/too. Meaning: ten.",
+    "type": "kanji",
+    "chars": [
+      [
+        "十",
+        "juu/too"
+      ]
+    ],
+    "vocab": [
+      [
+        "十",
+        "juu/too",
+        "ten"
+      ],
+      [
+        "じゅうにち",
+        "じゅうにち",
+        "じゅうにち=10th day"
+      ]
+    ],
+    "grammar": {
+      "pattern": "十 in words",
+      "meaning": "ten",
+      "example_jp": "じゅうにち=10th day",
+      "example_en": "ten"
+    },
+    "practice": "Write 十 20 times. Learn: じゅうにち=10th day",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 十 and practice carefully!"
+  },
+  {
+    "day": 263,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 38,
+    "title": "Kanji: 百 (hundred)",
+    "intro": "Today's kanji: 百. Readings: hyaku. Meaning: hundred.",
+    "type": "kanji",
+    "chars": [
+      [
+        "百",
+        "hyaku"
+      ]
+    ],
+    "vocab": [
+      [
+        "百",
+        "hyaku",
+        "hundred"
+      ],
+      [
+        "ひゃくえん",
+        "ひゃくえん",
+        "ひゃくえん=100 yen"
+      ]
+    ],
+    "grammar": {
+      "pattern": "百 in words",
+      "meaning": "hundred",
+      "example_jp": "ひゃくえん=100 yen",
+      "example_en": "hundred"
+    },
+    "practice": "Write 百 20 times. Learn: ひゃくえん=100 yen",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 百 and practice carefully!"
+  },
+  {
+    "day": 264,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 38,
+    "title": "Kanji: 千 (thousand)",
+    "intro": "Today's kanji: 千. Readings: sen. Meaning: thousand.",
+    "type": "kanji",
+    "chars": [
+      [
+        "千",
+        "sen"
+      ]
+    ],
+    "vocab": [
+      [
+        "千",
+        "sen",
+        "thousand"
+      ],
+      [
+        "せんえん",
+        "せんえん",
+        "せんえん=1000 yen"
+      ]
+    ],
+    "grammar": {
+      "pattern": "千 in words",
+      "meaning": "thousand",
+      "example_jp": "せんえん=1000 yen",
+      "example_en": "thousand"
+    },
+    "practice": "Write 千 20 times. Learn: せんえん=1000 yen",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 千 and practice carefully!"
+  },
+  {
+    "day": 265,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 38,
+    "title": "Kanji: 万 (ten thousand)",
+    "intro": "Today's kanji: 万. Readings: man. Meaning: ten thousand.",
+    "type": "kanji",
+    "chars": [
+      [
+        "万",
+        "man"
+      ]
+    ],
+    "vocab": [
+      [
+        "万",
+        "man",
+        "ten thousand"
+      ],
+      [
+        "いちまんえん",
+        "いちまんえん",
+        "いちまんえん=10,000 yen"
+      ]
+    ],
+    "grammar": {
+      "pattern": "万 in words",
+      "meaning": "ten thousand",
+      "example_jp": "いちまんえん=10",
+      "example_en": "ten thousand"
+    },
+    "practice": "Write 万 20 times. Learn: いちまんえん=10,000 yen",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 万 and practice carefully!"
+  },
+  {
+    "day": 266,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 38,
+    "title": "Kanji: 円 (yen/circle)",
+    "intro": "Today's kanji: 円. Readings: en/maru. Meaning: yen/circle.",
+    "type": "kanji",
+    "chars": [
+      [
+        "円",
+        "en/maru"
+      ]
+    ],
+    "vocab": [
+      [
+        "円",
+        "en/maru",
+        "yen/circle"
+      ],
+      [
+        "えん",
+        "えん",
+        "えん=yen currency"
+      ]
+    ],
+    "grammar": {
+      "pattern": "円 in words",
+      "meaning": "yen/circle",
+      "example_jp": "えん=yen currency",
+      "example_en": "yen/circle"
+    },
+    "practice": "Write 円 20 times. Learn: えん=yen currency",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 円 and practice carefully!"
+  },
+  {
+    "day": 267,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 39,
+    "title": "Kanji: 年 (year)",
+    "intro": "Today's kanji: 年. Readings: nen/toshi. Meaning: year.",
+    "type": "kanji",
+    "chars": [
+      [
+        "年",
+        "nen/toshi"
+      ]
+    ],
+    "vocab": [
+      [
+        "年",
+        "nen/toshi",
+        "year"
+      ],
+      [
+        "ことし",
+        "ことし",
+        "ことし=this year, いちねん=1 year"
+      ]
+    ],
+    "grammar": {
+      "pattern": "年 in words",
+      "meaning": "year",
+      "example_jp": "ことし=this year",
+      "example_en": "year"
+    },
+    "practice": "Write 年 20 times. Learn: ことし=this year, いちねん=1 year",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 年 and practice carefully!"
+  },
+  {
+    "day": 268,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 39,
+    "title": "Kanji: 月 (month/moon)",
+    "intro": "Today's kanji: 月. Readings: tsuki/gatsu. Meaning: month/moon.",
+    "type": "kanji",
+    "chars": [
+      [
+        "月",
+        "tsuki/gatsu"
+      ]
+    ],
+    "vocab": [
+      [
+        "月",
+        "tsuki/gatsu",
+        "month/moon"
+      ],
+      [
+        "こんげつ",
+        "こんげつ",
+        "こんげつ=this month, つき=moon"
+      ]
+    ],
+    "grammar": {
+      "pattern": "月 in words",
+      "meaning": "month/moon",
+      "example_jp": "こんげつ=this month",
+      "example_en": "month/moon"
+    },
+    "practice": "Write 月 20 times. Learn: こんげつ=this month, つき=moon",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 月 and practice carefully!"
+  },
+  {
+    "day": 269,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 39,
+    "title": "Kanji: 日 (day/sun)",
+    "intro": "Today's kanji: 日. Readings: nichi/ka/hi. Meaning: day/sun.",
+    "type": "kanji",
+    "chars": [
+      [
+        "日",
+        "nichi/ka/hi"
+      ]
+    ],
+    "vocab": [
+      [
+        "日",
+        "nichi/ka/hi",
+        "day/sun"
+      ],
+      [
+        "きょう",
+        "きょう",
+        "きょう=today, まいにち=every day"
+      ]
+    ],
+    "grammar": {
+      "pattern": "日 in words",
+      "meaning": "day/sun",
+      "example_jp": "きょう=today",
+      "example_en": "day/sun"
+    },
+    "practice": "Write 日 20 times. Learn: きょう=today, まいにち=every day",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 日 and practice carefully!"
+  },
+  {
+    "day": 270,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 39,
+    "title": "Kanji: 時 (time/hour)",
+    "intro": "Today's kanji: 時. Readings: ji/toki. Meaning: time/hour.",
+    "type": "kanji",
+    "chars": [
+      [
+        "時",
+        "ji/toki"
+      ]
+    ],
+    "vocab": [
+      [
+        "時",
+        "ji/toki",
+        "time/hour"
+      ],
+      [
+        "なんじ",
+        "なんじ",
+        "なんじ=what time, いまのとき=now"
+      ]
+    ],
+    "grammar": {
+      "pattern": "時 in words",
+      "meaning": "time/hour",
+      "example_jp": "なんじ=what time",
+      "example_en": "time/hour"
+    },
+    "practice": "Write 時 20 times. Learn: なんじ=what time, いまのとき=now",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 時 and practice carefully!"
+  },
+  {
+    "day": 271,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 39,
+    "title": "Kanji: 分 (minute/divide)",
+    "intro": "Today's kanji: 分. Readings: fun/pun/wak. Meaning: minute/divide.",
+    "type": "kanji",
+    "chars": [
+      [
+        "分",
+        "fun/pun/wak"
+      ]
+    ],
+    "vocab": [
+      [
+        "分",
+        "fun/pun/wak",
+        "minute/divide"
+      ],
+      [
+        "ごふん",
+        "ごふん",
+        "ごふん=5 min, わかる=understand"
+      ]
+    ],
+    "grammar": {
+      "pattern": "分 in words",
+      "meaning": "minute/divide",
+      "example_jp": "ごふん=5 min",
+      "example_en": "minute/divide"
+    },
+    "practice": "Write 分 20 times. Learn: ごふん=5 min, わかる=understand",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 分 and practice carefully!"
+  },
+  {
+    "day": 272,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 39,
+    "title": "Kanji: 週 (week)",
+    "intro": "Today's kanji: 週. Readings: shuu. Meaning: week.",
+    "type": "kanji",
+    "chars": [
+      [
+        "週",
+        "shuu"
+      ]
+    ],
+    "vocab": [
+      [
+        "週",
+        "shuu",
+        "week"
+      ],
+      [
+        "こんしゅう",
+        "こんしゅう",
+        "こんしゅう=this week"
+      ]
+    ],
+    "grammar": {
+      "pattern": "週 in words",
+      "meaning": "week",
+      "example_jp": "こんしゅう=this week",
+      "example_en": "week"
+    },
+    "practice": "Write 週 20 times. Learn: こんしゅう=this week",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 週 and practice carefully!"
+  },
+  {
+    "day": 273,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 39,
+    "title": "Kanji: 間 (between/space)",
+    "intro": "Today's kanji: 間. Readings: kan/aida. Meaning: between/space.",
+    "type": "kanji",
+    "chars": [
+      [
+        "間",
+        "kan/aida"
+      ]
+    ],
+    "vocab": [
+      [
+        "間",
+        "kan/aida",
+        "between/space"
+      ],
+      [
+        "じかん",
+        "じかん",
+        "じかん=time, あいだ=between"
+      ]
+    ],
+    "grammar": {
+      "pattern": "間 in words",
+      "meaning": "between/space",
+      "example_jp": "じかん=time",
+      "example_en": "between/space"
+    },
+    "practice": "Write 間 20 times. Learn: じかん=time, あいだ=between",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 間 and practice carefully!"
+  },
+  {
+    "day": 274,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 40,
+    "title": "Kanji: 今 (now)",
+    "intro": "Today's kanji: 今. Readings: ima/kon. Meaning: now.",
+    "type": "kanji",
+    "chars": [
+      [
+        "今",
+        "ima/kon"
+      ]
+    ],
+    "vocab": [
+      [
+        "今",
+        "ima/kon",
+        "now"
+      ],
+      [
+        "いま",
+        "いま",
+        "いま=now, こんにち=today"
+      ]
+    ],
+    "grammar": {
+      "pattern": "今 in words",
+      "meaning": "now",
+      "example_jp": "いま=now",
+      "example_en": "now"
+    },
+    "practice": "Write 今 20 times. Learn: いま=now, こんにち=today",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 今 and practice carefully!"
+  },
+  {
+    "day": 275,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 40,
+    "title": "Kanji: 本 (book/origin)",
+    "intro": "Today's kanji: 本. Readings: hon/moto. Meaning: book/origin.",
+    "type": "kanji",
+    "chars": [
+      [
+        "本",
+        "hon/moto"
+      ]
+    ],
+    "vocab": [
+      [
+        "本",
+        "hon/moto",
+        "book/origin"
+      ],
+      [
+        "ほん",
+        "ほん",
+        "ほん=book, にほん=Japan"
+      ]
+    ],
+    "grammar": {
+      "pattern": "本 in words",
+      "meaning": "book/origin",
+      "example_jp": "ほん=book",
+      "example_en": "book/origin"
+    },
+    "practice": "Write 本 20 times. Learn: ほん=book, にほん=Japan",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 本 and practice carefully!"
+  },
+  {
+    "day": 276,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 40,
+    "title": "Kanji: 語 (language)",
+    "intro": "Today's kanji: 語. Readings: go. Meaning: language.",
+    "type": "kanji",
+    "chars": [
+      [
+        "語",
+        "go"
+      ]
+    ],
+    "vocab": [
+      [
+        "語",
+        "go",
+        "language"
+      ],
+      [
+        "にほんご",
+        "にほんご",
+        "にほんご=Japanese"
+      ]
+    ],
+    "grammar": {
+      "pattern": "語 in words",
+      "meaning": "language",
+      "example_jp": "にほんご=Japanese",
+      "example_en": "language"
+    },
+    "practice": "Write 語 20 times. Learn: にほんご=Japanese",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 語 and practice carefully!"
+  },
+  {
+    "day": 277,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 40,
+    "title": "Kanji: 字 (character/letter)",
+    "intro": "Today's kanji: 字. Readings: ji. Meaning: character/letter.",
+    "type": "kanji",
+    "chars": [
+      [
+        "字",
+        "ji"
+      ]
+    ],
+    "vocab": [
+      [
+        "字",
+        "ji",
+        "character/letter"
+      ],
+      [
+        "もじ",
+        "もじ",
+        "もじ=written character, かんじ=kanji"
+      ]
+    ],
+    "grammar": {
+      "pattern": "字 in words",
+      "meaning": "character/letter",
+      "example_jp": "もじ=written character",
+      "example_en": "character/letter"
+    },
+    "practice": "Write 字 20 times. Learn: もじ=written character, かんじ=kanji",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 字 and practice carefully!"
+  },
+  {
+    "day": 278,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 40,
+    "title": "Kanji: 学 (study)",
+    "intro": "Today's kanji: 学. Readings: gaku/mana. Meaning: study.",
+    "type": "kanji",
+    "chars": [
+      [
+        "学",
+        "gaku/mana"
+      ]
+    ],
+    "vocab": [
+      [
+        "学",
+        "gaku/mana",
+        "study"
+      ],
+      [
+        "だいがく",
+        "だいがく",
+        "だいがく=university, がくせい=student"
+      ]
+    ],
+    "grammar": {
+      "pattern": "学 in words",
+      "meaning": "study",
+      "example_jp": "だいがく=university",
+      "example_en": "study"
+    },
+    "practice": "Write 学 20 times. Learn: だいがく=university, がくせい=student",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 学 and practice carefully!"
+  },
+  {
+    "day": 279,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 40,
+    "title": "Kanji: 校 (school)",
+    "intro": "Today's kanji: 校. Readings: kou. Meaning: school.",
+    "type": "kanji",
+    "chars": [
+      [
+        "校",
+        "kou"
+      ]
+    ],
+    "vocab": [
+      [
+        "校",
+        "kou",
+        "school"
+      ],
+      [
+        "がっこう",
+        "がっこう",
+        "がっこう=school, こうちょう=principal"
+      ]
+    ],
+    "grammar": {
+      "pattern": "校 in words",
+      "meaning": "school",
+      "example_jp": "がっこう=school",
+      "example_en": "school"
+    },
+    "practice": "Write 校 20 times. Learn: がっこう=school, こうちょう=principal",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 校 and practice carefully!"
+  },
+  {
+    "day": 280,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 40,
+    "title": "Kanji: 先 (before/ahead)",
+    "intro": "Today's kanji: 先. Readings: sen/saki. Meaning: before/ahead.",
+    "type": "kanji",
+    "chars": [
+      [
+        "先",
+        "sen/saki"
+      ]
+    ],
+    "vocab": [
+      [
+        "先",
+        "sen/saki",
+        "before/ahead"
+      ],
+      [
+        "せんせい",
+        "せんせい",
+        "せんせい=teacher, さき=ahead"
+      ]
+    ],
+    "grammar": {
+      "pattern": "先 in words",
+      "meaning": "before/ahead",
+      "example_jp": "せんせい=teacher",
+      "example_en": "before/ahead"
+    },
+    "practice": "Write 先 20 times. Learn: せんせい=teacher, さき=ahead",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 先 and practice carefully!"
+  },
+  {
+    "day": 281,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 41,
+    "title": "Kanji: 生 (life/birth)",
+    "intro": "Today's kanji: 生. Readings: sei/i/u. Meaning: life/birth.",
+    "type": "kanji",
+    "chars": [
+      [
+        "生",
+        "sei/i/u"
+      ]
+    ],
+    "vocab": [
+      [
+        "生",
+        "sei/i/u",
+        "life/birth"
+      ],
+      [
+        "がくせい",
+        "がくせい",
+        "がくせい=student, うまれる=be born"
+      ]
+    ],
+    "grammar": {
+      "pattern": "生 in words",
+      "meaning": "life/birth",
+      "example_jp": "がくせい=student",
+      "example_en": "life/birth"
+    },
+    "practice": "Write 生 20 times. Learn: がくせい=student, うまれる=be born",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 生 and practice carefully!"
+  },
+  {
+    "day": 282,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 41,
+    "title": "Kanji: 友 (friend)",
+    "intro": "Today's kanji: 友. Readings: yuu/tomo. Meaning: friend.",
+    "type": "kanji",
+    "chars": [
+      [
+        "友",
+        "yuu/tomo"
+      ]
+    ],
+    "vocab": [
+      [
+        "友",
+        "yuu/tomo",
+        "friend"
+      ],
+      [
+        "ともだち",
+        "ともだち",
+        "ともだち=friend, ゆうじん=friend (formal)"
+      ]
+    ],
+    "grammar": {
+      "pattern": "友 in words",
+      "meaning": "friend",
+      "example_jp": "ともだち=friend",
+      "example_en": "friend"
+    },
+    "practice": "Write 友 20 times. Learn: ともだち=friend, ゆうじん=friend (formal)",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 友 and practice carefully!"
+  },
+  {
+    "day": 283,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 41,
+    "title": "Kanji: 人 (person)",
+    "intro": "Today's kanji: 人. Readings: jin/hito. Meaning: person.",
+    "type": "kanji",
+    "chars": [
+      [
+        "人",
+        "jin/hito"
+      ]
+    ],
+    "vocab": [
+      [
+        "人",
+        "jin/hito",
+        "person"
+      ],
+      [
+        "にほんじん",
+        "にほんじん",
+        "にほんじん=Japanese, ひと=person"
+      ]
+    ],
+    "grammar": {
+      "pattern": "人 in words",
+      "meaning": "person",
+      "example_jp": "にほんじん=Japanese",
+      "example_en": "person"
+    },
+    "practice": "Write 人 20 times. Learn: にほんじん=Japanese, ひと=person",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 人 and practice carefully!"
+  },
+  {
+    "day": 284,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 41,
+    "title": "Kanji: 名 (name)",
+    "intro": "Today's kanji: 名. Readings: mei/na. Meaning: name.",
+    "type": "kanji",
+    "chars": [
+      [
+        "名",
+        "mei/na"
+      ]
+    ],
+    "vocab": [
+      [
+        "名",
+        "mei/na",
+        "name"
+      ],
+      [
+        "なまえ",
+        "なまえ",
+        "なまえ=name, めいし=business card"
+      ]
+    ],
+    "grammar": {
+      "pattern": "名 in words",
+      "meaning": "name",
+      "example_jp": "なまえ=name",
+      "example_en": "name"
+    },
+    "practice": "Write 名 20 times. Learn: なまえ=name, めいし=business card",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 名 and practice carefully!"
+  },
+  {
+    "day": 285,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 41,
+    "title": "Kanji: 電 (electricity)",
+    "intro": "Today's kanji: 電. Readings: den. Meaning: electricity.",
+    "type": "kanji",
+    "chars": [
+      [
+        "電",
+        "den"
+      ]
+    ],
+    "vocab": [
+      [
+        "電",
+        "den",
+        "electricity"
+      ],
+      [
+        "でんしゃ",
+        "でんしゃ",
+        "でんしゃ=train, でんわ=phone, でんき=electricity"
+      ]
+    ],
+    "grammar": {
+      "pattern": "電 in words",
+      "meaning": "electricity",
+      "example_jp": "でんしゃ=train",
+      "example_en": "electricity"
+    },
+    "practice": "Write 電 20 times. Learn: でんしゃ=train, でんわ=phone, でんき=electricity",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 電 and practice carefully!"
+  },
+  {
+    "day": 286,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 41,
+    "title": "Kanji: 話 (speech/talk)",
+    "intro": "Today's kanji: 話. Readings: wa/hana. Meaning: speech/talk.",
+    "type": "kanji",
+    "chars": [
+      [
+        "話",
+        "wa/hana"
+      ]
+    ],
+    "vocab": [
+      [
+        "話",
+        "wa/hana",
+        "speech/talk"
+      ],
+      [
+        "でんわ",
+        "でんわ",
+        "でんわ=phone, はなす=speak"
+      ]
+    ],
+    "grammar": {
+      "pattern": "話 in words",
+      "meaning": "speech/talk",
+      "example_jp": "でんわ=phone",
+      "example_en": "speech/talk"
+    },
+    "practice": "Write 話 20 times. Learn: でんわ=phone, はなす=speak",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 話 and practice carefully!"
+  },
+  {
+    "day": 287,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 41,
+    "title": "Kanji: 何 (what)",
+    "intro": "Today's kanji: 何. Readings: nani/nan. Meaning: what.",
+    "type": "kanji",
+    "chars": [
+      [
+        "何",
+        "nani/nan"
+      ]
+    ],
+    "vocab": [
+      [
+        "何",
+        "nani/nan",
+        "what"
+      ],
+      [
+        "なに",
+        "なに",
+        "なに=what, なんじ=what time"
+      ]
+    ],
+    "grammar": {
+      "pattern": "何 in words",
+      "meaning": "what",
+      "example_jp": "なに=what",
+      "example_en": "what"
+    },
+    "practice": "Write 何 20 times. Learn: なに=what, なんじ=what time",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 何 and practice carefully!"
+  },
+  {
+    "day": 288,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 42,
+    "title": "Kanji: 大 (big)",
+    "intro": "Today's kanji: 大. Readings: dai/oo. Meaning: big.",
+    "type": "kanji",
+    "chars": [
+      [
+        "大",
+        "dai/oo"
+      ]
+    ],
+    "vocab": [
+      [
+        "大",
+        "dai/oo",
+        "big"
+      ],
+      [
+        "おおきい",
+        "おおきい",
+        "おおきい=big, だいがく=university"
+      ]
+    ],
+    "grammar": {
+      "pattern": "大 in words",
+      "meaning": "big",
+      "example_jp": "おおきい=big",
+      "example_en": "big"
+    },
+    "practice": "Write 大 20 times. Learn: おおきい=big, だいがく=university",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 大 and practice carefully!"
+  },
+  {
+    "day": 289,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 42,
+    "title": "Kanji: 小 (small)",
+    "intro": "Today's kanji: 小. Readings: shou/chii. Meaning: small.",
+    "type": "kanji",
+    "chars": [
+      [
+        "小",
+        "shou/chii"
+      ]
+    ],
+    "vocab": [
+      [
+        "小",
+        "shou/chii",
+        "small"
+      ],
+      [
+        "ちいさい",
+        "ちいさい",
+        "ちいさい=small, しょうがっこう=elementary school"
+      ]
+    ],
+    "grammar": {
+      "pattern": "小 in words",
+      "meaning": "small",
+      "example_jp": "ちいさい=small",
+      "example_en": "small"
+    },
+    "practice": "Write 小 20 times. Learn: ちいさい=small, しょうがっこう=elementary school",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 小 and practice carefully!"
+  },
+  {
+    "day": 290,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 42,
+    "title": "Kanji: 山 (mountain)",
+    "intro": "Today's kanji: 山. Readings: san/yama. Meaning: mountain.",
+    "type": "kanji",
+    "chars": [
+      [
+        "山",
+        "san/yama"
+      ]
+    ],
+    "vocab": [
+      [
+        "山",
+        "san/yama",
+        "mountain"
+      ],
+      [
+        "やま",
+        "やま",
+        "やま=mountain, ふじさん=Mt Fuji"
+      ]
+    ],
+    "grammar": {
+      "pattern": "山 in words",
+      "meaning": "mountain",
+      "example_jp": "やま=mountain",
+      "example_en": "mountain"
+    },
+    "practice": "Write 山 20 times. Learn: やま=mountain, ふじさん=Mt Fuji",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 山 and practice carefully!"
+  },
+  {
+    "day": 291,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 42,
+    "title": "Kanji: 川 (river)",
+    "intro": "Today's kanji: 川. Readings: sen/kawa. Meaning: river.",
+    "type": "kanji",
+    "chars": [
+      [
+        "川",
+        "sen/kawa"
+      ]
+    ],
+    "vocab": [
+      [
+        "川",
+        "sen/kawa",
+        "river"
+      ],
+      [
+        "かわ",
+        "かわ",
+        "かわ=river, もがわ=various rivers"
+      ]
+    ],
+    "grammar": {
+      "pattern": "川 in words",
+      "meaning": "river",
+      "example_jp": "かわ=river",
+      "example_en": "river"
+    },
+    "practice": "Write 川 20 times. Learn: かわ=river, もがわ=various rivers",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 川 and practice carefully!"
+  },
+  {
+    "day": 292,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 42,
+    "title": "Kanji: 空 (sky/empty)",
+    "intro": "Today's kanji: 空. Readings: kuu/sora/a. Meaning: sky/empty.",
+    "type": "kanji",
+    "chars": [
+      [
+        "空",
+        "kuu/sora/a"
+      ]
+    ],
+    "vocab": [
+      [
+        "空",
+        "kuu/sora/a",
+        "sky/empty"
+      ],
+      [
+        "そら",
+        "そら",
+        "そら=sky, くうこう=airport"
+      ]
+    ],
+    "grammar": {
+      "pattern": "空 in words",
+      "meaning": "sky/empty",
+      "example_jp": "そら=sky",
+      "example_en": "sky/empty"
+    },
+    "practice": "Write 空 20 times. Learn: そら=sky, くうこう=airport",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 空 and practice carefully!"
+  },
+  {
+    "day": 293,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 42,
+    "title": "Kanji: 海 (sea)",
+    "intro": "Today's kanji: 海. Readings: kai/umi. Meaning: sea.",
+    "type": "kanji",
+    "chars": [
+      [
+        "海",
+        "kai/umi"
+      ]
+    ],
+    "vocab": [
+      [
+        "海",
+        "kai/umi",
+        "sea"
+      ],
+      [
+        "うみ",
+        "うみ",
+        "うみ=sea, かいすいよく=sea bathing"
+      ]
+    ],
+    "grammar": {
+      "pattern": "海 in words",
+      "meaning": "sea",
+      "example_jp": "うみ=sea",
+      "example_en": "sea"
+    },
+    "practice": "Write 海 20 times. Learn: うみ=sea, かいすいよく=sea bathing",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 海 and practice carefully!"
+  },
+  {
+    "day": 294,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 42,
+    "title": "Kanji: 土 (earth/soil)",
+    "intro": "Today's kanji: 土. Readings: do/tsuchi. Meaning: earth/soil.",
+    "type": "kanji",
+    "chars": [
+      [
+        "土",
+        "do/tsuchi"
+      ]
+    ],
+    "vocab": [
+      [
+        "土",
+        "do/tsuchi",
+        "earth/soil"
+      ],
+      [
+        "どようび",
+        "どようび",
+        "どようび=Saturday, つち=soil"
+      ]
+    ],
+    "grammar": {
+      "pattern": "土 in words",
+      "meaning": "earth/soil",
+      "example_jp": "どようび=Saturday",
+      "example_en": "earth/soil"
+    },
+    "practice": "Write 土 20 times. Learn: どようび=Saturday, つち=soil",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 土 and practice carefully!"
+  },
+  {
+    "day": 295,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 43,
+    "title": "Kanji: 木 (tree/wood)",
+    "intro": "Today's kanji: 木. Readings: moku/ki. Meaning: tree/wood.",
+    "type": "kanji",
+    "chars": [
+      [
+        "木",
+        "moku/ki"
+      ]
+    ],
+    "vocab": [
+      [
+        "木",
+        "moku/ki",
+        "tree/wood"
+      ],
+      [
+        "き",
+        "き",
+        "き=tree, もくようび=Thursday"
+      ]
+    ],
+    "grammar": {
+      "pattern": "木 in words",
+      "meaning": "tree/wood",
+      "example_jp": "き=tree",
+      "example_en": "tree/wood"
+    },
+    "practice": "Write 木 20 times. Learn: き=tree, もくようび=Thursday",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 木 and practice carefully!"
+  },
+  {
+    "day": 296,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 43,
+    "title": "Kanji: 火 (fire)",
+    "intro": "Today's kanji: 火. Readings: ka/hi. Meaning: fire.",
+    "type": "kanji",
+    "chars": [
+      [
+        "火",
+        "ka/hi"
+      ]
+    ],
+    "vocab": [
+      [
+        "火",
+        "ka/hi",
+        "fire"
+      ],
+      [
+        "ひ",
+        "ひ",
+        "ひ=fire, かようび=Tuesday"
+      ]
+    ],
+    "grammar": {
+      "pattern": "火 in words",
+      "meaning": "fire",
+      "example_jp": "ひ=fire",
+      "example_en": "fire"
+    },
+    "practice": "Write 火 20 times. Learn: ひ=fire, かようび=Tuesday",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 火 and practice carefully!"
+  },
+  {
+    "day": 297,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 43,
+    "title": "Kanji: 水 (water)",
+    "intro": "Today's kanji: 水. Readings: sui/mizu. Meaning: water.",
+    "type": "kanji",
+    "chars": [
+      [
+        "水",
+        "sui/mizu"
+      ]
+    ],
+    "vocab": [
+      [
+        "水",
+        "sui/mizu",
+        "water"
+      ],
+      [
+        "みず",
+        "みず",
+        "みず=water, すいようび=Wednesday"
+      ]
+    ],
+    "grammar": {
+      "pattern": "水 in words",
+      "meaning": "water",
+      "example_jp": "みず=water",
+      "example_en": "water"
+    },
+    "practice": "Write 水 20 times. Learn: みず=water, すいようび=Wednesday",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 水 and practice carefully!"
+  },
+  {
+    "day": 298,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 43,
+    "title": "Kanji: 金 (gold/money)",
+    "intro": "Today's kanji: 金. Readings: kin/kana. Meaning: gold/money.",
+    "type": "kanji",
+    "chars": [
+      [
+        "金",
+        "kin/kana"
+      ]
+    ],
+    "vocab": [
+      [
+        "金",
+        "kin/kana",
+        "gold/money"
+      ],
+      [
+        "おかね",
+        "おかね",
+        "おかね=money, きんようび=Friday"
+      ]
+    ],
+    "grammar": {
+      "pattern": "金 in words",
+      "meaning": "gold/money",
+      "example_jp": "おかね=money",
+      "example_en": "gold/money"
+    },
+    "practice": "Write 金 20 times. Learn: おかね=money, きんようび=Friday",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 金 and practice carefully!"
+  },
+  {
+    "day": 299,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 43,
+    "title": "Kanji: 女 (woman)",
+    "intro": "Today's kanji: 女. Readings: jo/onna. Meaning: woman.",
+    "type": "kanji",
+    "chars": [
+      [
+        "女",
+        "jo/onna"
+      ]
+    ],
+    "vocab": [
+      [
+        "女",
+        "jo/onna",
+        "woman"
+      ],
+      [
+        "おんなのひと",
+        "おんなのひと",
+        "おんなのひと=woman, じょせい=female"
+      ]
+    ],
+    "grammar": {
+      "pattern": "女 in words",
+      "meaning": "woman",
+      "example_jp": "おんなのひと=woman",
+      "example_en": "woman"
+    },
+    "practice": "Write 女 20 times. Learn: おんなのひと=woman, じょせい=female",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 女 and practice carefully!"
+  },
+  {
+    "day": 300,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 43,
+    "title": "Kanji: 男 (man)",
+    "intro": "Today's kanji: 男. Readings: dan/otoko. Meaning: man.",
+    "type": "kanji",
+    "chars": [
+      [
+        "男",
+        "dan/otoko"
+      ]
+    ],
+    "vocab": [
+      [
+        "男",
+        "dan/otoko",
+        "man"
+      ],
+      [
+        "おとこのひと",
+        "おとこのひと",
+        "おとこのひと=man, だんせい=male"
+      ]
+    ],
+    "grammar": {
+      "pattern": "男 in words",
+      "meaning": "man",
+      "example_jp": "おとこのひと=man",
+      "example_en": "man"
+    },
+    "practice": "Write 男 20 times. Learn: おとこのひと=man, だんせい=male",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 男 and practice carefully!"
+  },
+  {
+    "day": 301,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 43,
+    "title": "Kanji: 車 (car)",
+    "intro": "Today's kanji: 車. Readings: sha/kuruma. Meaning: car.",
+    "type": "kanji",
+    "chars": [
+      [
+        "車",
+        "sha/kuruma"
+      ]
+    ],
+    "vocab": [
+      [
+        "車",
+        "sha/kuruma",
+        "car"
+      ],
+      [
+        "くるま",
+        "くるま",
+        "くるま=car, でんしゃ=train"
+      ]
+    ],
+    "grammar": {
+      "pattern": "車 in words",
+      "meaning": "car",
+      "example_jp": "くるま=car",
+      "example_en": "car"
+    },
+    "practice": "Write 車 20 times. Learn: くるま=car, でんしゃ=train",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 車 and practice carefully!"
+  },
+  {
+    "day": 302,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 44,
+    "title": "Kanji: 道 (road/way)",
+    "intro": "Today's kanji: 道. Readings: dou/michi. Meaning: road/way.",
+    "type": "kanji",
+    "chars": [
+      [
+        "道",
+        "dou/michi"
+      ]
+    ],
+    "vocab": [
+      [
+        "道",
+        "dou/michi",
+        "road/way"
+      ],
+      [
+        "みち",
+        "みち",
+        "みち=road, どうろ=road/street"
+      ]
+    ],
+    "grammar": {
+      "pattern": "道 in words",
+      "meaning": "road/way",
+      "example_jp": "みち=road",
+      "example_en": "road/way"
+    },
+    "practice": "Write 道 20 times. Learn: みち=road, どうろ=road/street",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 道 and practice carefully!"
+  },
+  {
+    "day": 303,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 44,
+    "title": "Kanji: 国 (country)",
+    "intro": "Today's kanji: 国. Readings: koku/kuni. Meaning: country.",
+    "type": "kanji",
+    "chars": [
+      [
+        "国",
+        "koku/kuni"
+      ]
+    ],
+    "vocab": [
+      [
+        "国",
+        "koku/kuni",
+        "country"
+      ],
+      [
+        "くに",
+        "くに",
+        "くに=country, にほんこく=Japan"
+      ]
+    ],
+    "grammar": {
+      "pattern": "国 in words",
+      "meaning": "country",
+      "example_jp": "くに=country",
+      "example_en": "country"
+    },
+    "practice": "Write 国 20 times. Learn: くに=country, にほんこく=Japan",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 国 and practice carefully!"
+  },
+  {
+    "day": 304,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 44,
+    "title": "Kanji: 外 (outside/foreign)",
+    "intro": "Today's kanji: 外. Readings: gai/soto. Meaning: outside/foreign.",
+    "type": "kanji",
+    "chars": [
+      [
+        "外",
+        "gai/soto"
+      ]
+    ],
+    "vocab": [
+      [
+        "外",
+        "gai/soto",
+        "outside/foreign"
+      ],
+      [
+        "そと",
+        "そと",
+        "そと=outside, がいこく=foreign country"
+      ]
+    ],
+    "grammar": {
+      "pattern": "外 in words",
+      "meaning": "outside/foreign",
+      "example_jp": "そと=outside",
+      "example_en": "outside/foreign"
+    },
+    "practice": "Write 外 20 times. Learn: そと=outside, がいこく=foreign country",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 外 and practice carefully!"
+  },
+  {
+    "day": 305,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 44,
+    "title": "Kanji: 上 (above/up)",
+    "intro": "Today's kanji: 上. Readings: jou/ue. Meaning: above/up.",
+    "type": "kanji",
+    "chars": [
+      [
+        "上",
+        "jou/ue"
+      ]
+    ],
+    "vocab": [
+      [
+        "上",
+        "jou/ue",
+        "above/up"
+      ],
+      [
+        "うえ",
+        "うえ",
+        "うえ=above, うえに=on top of"
+      ]
+    ],
+    "grammar": {
+      "pattern": "上 in words",
+      "meaning": "above/up",
+      "example_jp": "うえ=above",
+      "example_en": "above/up"
+    },
+    "practice": "Write 上 20 times. Learn: うえ=above, うえに=on top of",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 上 and practice carefully!"
+  },
+  {
+    "day": 306,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 44,
+    "title": "Kanji: 下 (below/down)",
+    "intro": "Today's kanji: 下. Readings: ka/shita. Meaning: below/down.",
+    "type": "kanji",
+    "chars": [
+      [
+        "下",
+        "ka/shita"
+      ]
+    ],
+    "vocab": [
+      [
+        "下",
+        "ka/shita",
+        "below/down"
+      ],
+      [
+        "した",
+        "した",
+        "した=below, ちか=underground"
+      ]
+    ],
+    "grammar": {
+      "pattern": "下 in words",
+      "meaning": "below/down",
+      "example_jp": "した=below",
+      "example_en": "below/down"
+    },
+    "practice": "Write 下 20 times. Learn: した=below, ちか=underground",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 下 and practice carefully!"
+  },
+  {
+    "day": 307,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 44,
+    "title": "Kanji: 右 (right)",
+    "intro": "Today's kanji: 右. Readings: u/migi. Meaning: right.",
+    "type": "kanji",
+    "chars": [
+      [
+        "右",
+        "u/migi"
+      ]
+    ],
+    "vocab": [
+      [
+        "右",
+        "u/migi",
+        "right"
+      ],
+      [
+        "みぎ",
+        "みぎ",
+        "みぎ=right, みぎて=right hand"
+      ]
+    ],
+    "grammar": {
+      "pattern": "右 in words",
+      "meaning": "right",
+      "example_jp": "みぎ=right",
+      "example_en": "right"
+    },
+    "practice": "Write 右 20 times. Learn: みぎ=right, みぎて=right hand",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 右 and practice carefully!"
+  },
+  {
+    "day": 308,
+    "phaseNum": 7,
+    "phaseName": "Kanji",
+    "week": 44,
+    "title": "Kanji: 左 (left)",
+    "intro": "Today's kanji: 左. Readings: sa/hidari. Meaning: left.",
+    "type": "kanji",
+    "chars": [
+      [
+        "左",
+        "sa/hidari"
+      ]
+    ],
+    "vocab": [
+      [
+        "左",
+        "sa/hidari",
+        "left"
+      ],
+      [
+        "ひだり",
+        "ひだり",
+        "ひだり=left, ひだりて=left hand"
+      ]
+    ],
+    "grammar": {
+      "pattern": "左 in words",
+      "meaning": "left",
+      "example_jp": "ひだり=left",
+      "example_en": "left"
+    },
+    "practice": "Write 左 20 times. Learn: ひだり=left, ひだりて=left hand",
+    "tip": "Stroke order matters in Japanese. Look up the correct stroke order for 左 and practice carefully!"
+  },
+  {
+    "day": 309,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 45,
+    "title": "Hiragana & Katakana Speed Reading",
+    "intro": "Speed is key on the JLPT! Practice reading kana as fast as possible today.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 310,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 45,
+    "title": "Kanji Recognition Review (一〜百)",
+    "intro": "Test yourself on the number and time kanji. These appear frequently on N5.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 311,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 45,
+    "title": "Kanji Recognition Review (年〜電)",
+    "intro": "Today's focus: Kanji Recognition Review (年〜電). Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 312,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 45,
+    "title": "Kanji Recognition Review (何〜左)",
+    "intro": "Today's focus: Kanji Recognition Review (何〜左). Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 313,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 45,
+    "title": "Full Kanji Writing Test",
+    "intro": "Today's focus: Full Kanji Writing Test. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 314,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 45,
+    "title": "Vocabulary Review: People & Family",
+    "intro": "Today's focus: Vocabulary Review: People & Family. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 315,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 45,
+    "title": "Vocabulary Review: Places & Transport",
+    "intro": "Today's focus: Vocabulary Review: Places & Transport. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 316,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 46,
+    "title": "Vocabulary Review: Food & Daily Life",
+    "intro": "Today's focus: Vocabulary Review: Food & Daily Life. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 317,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 46,
+    "title": "Vocabulary Review: Nature & Weather",
+    "intro": "Today's focus: Vocabulary Review: Nature & Weather. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 318,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 46,
+    "title": "Vocabulary Review: Verbs (Actions)",
+    "intro": "Verbs are the heart of Japanese sentences. Review all action verbs learned in Phase 5.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 319,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 46,
+    "title": "Vocabulary Review: Adjectives",
+    "intro": "Today's focus: Vocabulary Review: Adjectives. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 320,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 46,
+    "title": "JLPT N5 Vocabulary Practice Test 1",
+    "intro": "Simulate exam conditions: timer on, no notes, choose the best answer.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 321,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 46,
+    "title": "JLPT N5 Vocabulary Practice Test 2",
+    "intro": "Today's focus: JLPT N5 Vocabulary Practice Test 2. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 322,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 46,
+    "title": "Particle Review: は・が・を・の",
+    "intro": "Today's focus: Particle Review: は・が・を・の. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 323,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 47,
+    "title": "Particle Review: に・で・と・から・まで",
+    "intro": "Today's focus: Particle Review: に・で・と・から・まで. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 324,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 47,
+    "title": "Grammar Review: て-form Uses",
+    "intro": "The て-form has so many uses! Review them all: request, sequence, progressive, permission.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 325,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 47,
+    "title": "Grammar Review: Verb Conjugation",
+    "intro": "Today's focus: Grammar Review: Verb Conjugation. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 326,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 47,
+    "title": "Grammar Review: Adjective Forms",
+    "intro": "Today's focus: Grammar Review: Adjective Forms. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 327,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 47,
+    "title": "Grammar Review: Permission & Obligation",
+    "intro": "Today's focus: Grammar Review: Permission & Obligation. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 328,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 47,
+    "title": "Grammar Review: Conditionals",
+    "intro": "Today's focus: Grammar Review: Conditionals. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 329,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 47,
+    "title": "JLPT N5 Grammar Practice Test 1",
+    "intro": "Timed practice. Try to answer each question in 30 seconds or less.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 330,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 48,
+    "title": "JLPT N5 Grammar Practice Test 2",
+    "intro": "Today's focus: JLPT N5 Grammar Practice Test 2. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 331,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 48,
+    "title": "Reading Practice: Short Passages (Daily Life)",
+    "intro": "N5 reading uses short, simple passages. Focus on scanning for key information.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 332,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 48,
+    "title": "Reading Practice: Emails & Messages",
+    "intro": "Today's focus: Reading Practice: Emails & Messages. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 333,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 48,
+    "title": "Reading Practice: Signs & Notices",
+    "intro": "Today's focus: Reading Practice: Signs & Notices. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 334,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 48,
+    "title": "Reading Practice: Short Stories",
+    "intro": "Today's focus: Reading Practice: Short Stories. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 335,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 48,
+    "title": "JLPT N5 Reading Practice Test",
+    "intro": "Today's focus: JLPT N5 Reading Practice Test. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 336,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 48,
+    "title": "Listening Strategy: Key Words",
+    "intro": "In JLPT listening, focus on key words (time, place, person, action) rather than understanding everything.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 337,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 49,
+    "title": "Listening Strategy: Numbers & Times",
+    "intro": "Today's focus: Listening Strategy: Numbers & Times. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 338,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 49,
+    "title": "Listening Strategy: Directions",
+    "intro": "Today's focus: Listening Strategy: Directions. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 339,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 49,
+    "title": "Listening Practice: Dialogues",
+    "intro": "Today's focus: Listening Practice: Dialogues. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 340,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 49,
+    "title": "JLPT N5 Listening Practice (Scripts)",
+    "intro": "Today's focus: JLPT N5 Listening Practice (Scripts). Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 341,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 49,
+    "title": "Mock Test 1: Vocabulary Section",
+    "intro": "Full simulation! Vocabulary section: 25 questions, 25 minutes.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 342,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 49,
+    "title": "Mock Test 1: Grammar Section",
+    "intro": "Today's focus: Mock Test 1: Grammar Section. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 343,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 49,
+    "title": "Mock Test 1: Reading Section",
+    "intro": "Today's focus: Mock Test 1: Reading Section. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 344,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 50,
+    "title": "Mock Test 1: Review & Analysis",
+    "intro": "Today's focus: Mock Test 1: Review & Analysis. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 345,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 50,
+    "title": "Weak Area Study: Vocabulary",
+    "intro": "Today's focus: Weak Area Study: Vocabulary. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 346,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 50,
+    "title": "Weak Area Study: Grammar",
+    "intro": "Today's focus: Weak Area Study: Grammar. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 347,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 50,
+    "title": "Weak Area Study: Kanji",
+    "intro": "Today's focus: Weak Area Study: Kanji. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 348,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 50,
+    "title": "Full Mock Test 2",
+    "intro": "Full N5 mock exam under exam conditions. 90 minutes total.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 349,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 50,
+    "title": "Mock Test 2: Review & Analysis",
+    "intro": "Today's focus: Mock Test 2: Review & Analysis. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 350,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 50,
+    "title": "JLPT Test-Taking Strategies",
+    "intro": "Today's focus: JLPT Test-Taking Strategies. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 351,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 51,
+    "title": "Time Management Practice",
+    "intro": "Today's focus: Time Management Practice. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 352,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 51,
+    "title": "Final Vocabulary Review",
+    "intro": "Today's focus: Final Vocabulary Review. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 353,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 51,
+    "title": "Final Grammar Review",
+    "intro": "Today's focus: Final Grammar Review. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 354,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 51,
+    "title": "Final Kanji Review",
+    "intro": "Today's focus: Final Kanji Review. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 355,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 51,
+    "title": "Confidence Building: What You Know",
+    "intro": "Today's focus: Confidence Building: What You Know. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 356,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 51,
+    "title": "Light Reading Practice",
+    "intro": "Today's focus: Light Reading Practice. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 357,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 51,
+    "title": "Final Mock Exam",
+    "intro": "Today's focus: Final Mock Exam. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 358,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Final Mock Exam: Review",
+    "intro": "Today's focus: Final Mock Exam: Review. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 359,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Rest & Light Review",
+    "intro": "Today's focus: Rest & Light Review. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 360,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Final Preparations",
+    "intro": "Today's focus: Final Preparations. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 361,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Relax & Prepare",
+    "intro": "Today's focus: Relax & Prepare. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 362,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Day Before Exam: Rest!",
+    "intro": "Today's focus: Day Before Exam: Rest!. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 363,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Day 365: Course Complete! 🎉",
+    "intro": "CONGRATULATIONS! You've completed 365 days of Japanese study! You're ready for JLPT N5!",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 364,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Day 365 Plus: What's Next (N4 Preview)",
+    "intro": "Today's focus: Day 365 Plus: What's Next (N4 Preview). Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Complete the full review/practice for today's topic. Write down any areas needing extra work.",
+    "tip": "You're in the home stretch! Every review day reinforces everything you've built over the past year."
+  },
+  {
+    "day": 365,
+    "phaseNum": 8,
+    "phaseName": "Test Prep",
+    "week": 52,
+    "title": "Day 366: Bonus — Japanese Culture Tips",
+    "intro": "Today's focus: Day 366: Bonus — Japanese Culture Tips. Review, practice, and consolidate what you've learned.",
+    "type": "review",
+    "chars": [],
+    "vocab": [
+      [
+        "れんしゅう",
+        "れんしゅう",
+        "practice"
+      ],
+      [
+        "かくにん",
+        "かくにん",
+        "confirmation/review"
+      ],
+      [
+        "もくひょう",
+        "もくひょう",
+        "goal"
+      ],
+      [
+        "しんちょく",
+        "しんちょく",
+        "progress"
+      ],
+      [
+        "じしん",
+        "じしん",
+        "confidence"
+      ]
+    ],
+    "grammar": {
+      "pattern": "Review & Practice",
+      "meaning": "N5 preparation",
+      "example_jp": "まいにち　すこしずつ　べんきょうして、ちからをつけましょう",
+      "example_en": "Study a little every day and build your ability"
+    },
+    "practice": "Celebrate your achievement! Write about everything you can now do in Japanese.",
+    "tip": "365 days completed! Celebrate this incredible achievement. Your N5 journey ends here — but your Japanese journey continues forever! Consider JLPT N4 next!"
+  }
+];

--- a/index.html
+++ b/index.html
@@ -190,6 +190,65 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
 "use strict";
 
 
+// ── Progressive UI Translations ──────────────────────────────────────────────
+// As learning-related words are taught in the curriculum, the UI progressively
+// switches from English to Japanese. Each entry has {en, ja, since} where
+// `since` is the day number when the Japanese word is first taught.
+var UI_STRINGS = {
+  // Navigation / header
+  day_label:      { en: 'Day',      ja: 'だい',       since: 38  },
+  week_label:     { en: 'Week',     ja: 'しゅう',     since: 39  },
+  of_365:         { en: 'of 365',   ja: '/ 365にち',  since: 38  },
+  view_review:    { en: 'Review',   ja: 'ふくしゅう', since: 49  },
+  // Day status
+  mark_complete:   { en: '✓ Mark Complete',   ja: '✓ かんりょう！', since: 203 },
+  mark_incomplete: { en: '✕ Mark Incomplete', ja: '✕ まだ',         since: 53  },
+  complete_badge:  { en: '✓ Complete',         ja: '✓ かんりょう',  since: 203 },
+  // Navigation buttons
+  nav_prev: { en: '← Previous', ja: '← まえ',   since: 62  },
+  nav_next: { en: 'Next →',     ja: 'つぎ →',   since: 109 },
+  // Section labels (inside a lesson)
+  section_characters: { en: 'Characters',    ja: 'もじ',       since: 277 },
+  section_vocabulary: { en: 'Vocabulary',    ja: 'たんご',     since: 140 },
+  section_grammar:    { en: 'Grammar Point', ja: 'ぶんぽう',   since: 183 },
+  section_practice:   { en: 'Practice',      ja: 'れんしゅう', since: 147 },
+  section_exercises:  { en: 'Exercises',     ja: 'もんだい',   since: 212 },
+  // Vocabulary table headers
+  vocab_word:    { en: 'Word',    ja: 'ことば', since: 139 },
+  vocab_reading: { en: 'Reading', ja: 'よみ',   since: 58  },
+  vocab_meaning: { en: 'Meaning', ja: 'いみ',   since: 137 },
+  // SRS review buttons
+  btn_again: { en: 'Again', ja: 'もういちど',  since: 47  },
+  btn_hard:  { en: 'Hard',  ja: 'むずかしい', since: 77  },
+  btn_good:  { en: 'Good',  ja: 'いい',       since: 44  },
+  btn_easy:  { en: 'Easy',  ja: 'かんたん',   since: 156 },
+  // Review card labels
+  card_char:    { en: 'Character',  ja: 'もじ',   since: 277 },
+  card_vocab:   { en: 'Vocabulary', ja: 'たんご', since: 140 },
+  tap_reveal:   { en: 'tap to reveal',                    ja: 'タップしてみる',  since: 15  },
+  click_reveal: { en: 'Click the card to see the answer', ja: 'カードをクリック！', since: 46 },
+  // Review completion messages
+  all_caught_up:  { en: 'All caught up!',      ja: 'ぜんぶおわった！',  since: 179 },
+  no_cards_due:   { en: 'No cards due for review right now.', ja: 'いまふくしゅうカードはありません。', since: 49 },
+  session_done:   { en: 'Session complete!',   ja: 'よくできました！',  since: 140 },
+  // Exercise / quiz labels
+  start_quiz:  { en: 'Start Quiz',               ja: 'テストをはじめる',     since: 117 },
+  try_again:   { en: 'Try Again',                ja: 'もういちど',            since: 47  },
+  quiz_title:  { en: 'Ready to test yourself?',  ja: 'テストのじかんです！',  since: 117 },
+  check_btn:   { en: 'Check',                    ja: 'かくにん',              since: 147 },
+  // Exercise prompts (translated once prerequisite words are taught)
+  prompt_listen:    { en: 'Listen and choose the meaning:', ja: 'きいて、いみをえらんでください：', since: 137 },
+  prompt_mc_char:   { en: 'What is the reading for this character?', ja: 'このもじのよみは？', since: 277 },
+  prompt_mc_word:   { en: 'What does this word mean?', ja: 'このことばのいみは？', since: 137 },
+  prompt_type_char: { en: 'Type the reading for this character:', ja: 'このもじのよみをにゅうりょくしてください：', since: 277 },
+  prompt_type_word: { en: 'What does this word mean? (type in English)', ja: 'このことばのいみは？（えいごで）', since: 137 },
+};
+function t(key, dayNum) {
+  var s = UI_STRINGS[key];
+  if (!s) return key;
+  return (dayNum >= s.since) ? s.ja : s.en;
+}
+
 // ── localStorage ─────────────────────────────────────────────────────────────
 var LS_KEY = 'n5_2025';
 function lsLoad() {
@@ -230,7 +289,8 @@ function speak(text) {
 // ── ReviewView ────────────────────────────────────────────────────────────────
 function ReviewView(_ref6) {
   var srs = _ref6.srs,
-    onUpdate = _ref6.onUpdate;
+    onUpdate = _ref6.onUpdate,
+    dayNum = _ref6.dayNum || 1;
   var dueIds = getDueCards(srs);
   var allItems = dueIds.map(function (id) {
     return cardToItem(id, srs);
@@ -264,9 +324,9 @@ function ReviewView(_ref6) {
       className: "review-done-icon"
     }, "\uD83C\uDF89"), /*#__PURE__*/React.createElement("div", {
       className: "review-done-title"
-    }, "All caught up!"), /*#__PURE__*/React.createElement("div", {
+    }, t('all_caught_up', dayNum)), /*#__PURE__*/React.createElement("div", {
       className: "review-done-sub"
-    }, "No cards due for review right now. Check back tomorrow!")));
+    }, t('no_cards_due', dayNum)));
   }
   if (cur >= queue.length) {
     return /*#__PURE__*/React.createElement("div", {
@@ -277,7 +337,7 @@ function ReviewView(_ref6) {
       className: "review-done-icon"
     }, "\u2705"), /*#__PURE__*/React.createElement("div", {
       className: "review-done-title"
-    }, "Session complete!"), /*#__PURE__*/React.createElement("div", {
+    }, t('session_done', dayNum)), /*#__PURE__*/React.createElement("div", {
       className: "review-done-sub"
     }, "\u2713 ", score.right, " correct \xB7 \u2717 ", score.wrong, " again")));
   }
@@ -315,7 +375,7 @@ function ReviewView(_ref6) {
     }
   }, "\uD83D\uDD0A"), !flipped && /*#__PURE__*/React.createElement("div", {
     className: "review-tap"
-  }, "tap to reveal"), flipped && /*#__PURE__*/React.createElement("div", {
+  }, t('tap_reveal', dayNum)), flipped && /*#__PURE__*/React.createElement("div", {
     className: "review-back"
   }, /*#__PURE__*/React.createElement("div", {
     className: "review-answer"
@@ -328,23 +388,37 @@ function ReviewView(_ref6) {
     onClick: function onClick() {
       return grade(1);
     }
-  }, "Again"), /*#__PURE__*/React.createElement("button", {
+  }, t('btn_again', dayNum)), /*#__PURE__*/React.createElement("button", {
     className: "review-btn good",
     onClick: function onClick() {
       return grade(3);
     }
-  }, "Good"), /*#__PURE__*/React.createElement("button", {
+  }, t('btn_good', dayNum)), /*#__PURE__*/React.createElement("button", {
     className: "review-btn easy",
     onClick: function onClick() {
       return grade(5);
     }
-  }, "Easy")) : /*#__PURE__*/React.createElement("div", {
+  }, t('btn_easy', dayNum))) : /*#__PURE__*/React.createElement("div", {
     style: {
       height: '56px'
     }
   }));
 }
 
+
+// Maps exercise prompt strings to UI_STRINGS keys for translation
+var PROMPT_KEYS = {
+  'Listen and choose the meaning:': 'prompt_listen',
+  'What is the reading for this character?': 'prompt_mc_char',
+  'What does this word mean?': 'prompt_mc_word',
+  'Type the reading for this character:': 'prompt_type_char',
+  'What does this word mean? (type in English)': 'prompt_type_word',
+};
+function translatePrompt(prompt, dayNum) {
+  var key = PROMPT_KEYS[prompt];
+  if (!key) return prompt;
+  return t(key, dayNum);
+}
 
 // ── TypingTip ────────────────────────────────────────────────────────────────
 var TYPING_NOTES = {
@@ -433,7 +507,7 @@ function Exercises(_ref9) {
       className: "quiz-start-box"
     }, /*#__PURE__*/React.createElement("div", {
       className: "quiz-start-title"
-    }, "Ready to test yourself?"), /*#__PURE__*/React.createElement("div", {
+    }, t('quiz_title', lesson.day)), /*#__PURE__*/React.createElement("div", {
       className: "quiz-start-hint"
     }, "The lesson content above will be hidden while you answer ", exs.length, " questions."), /*#__PURE__*/React.createElement("button", {
       className: "quiz-start-btn",
@@ -441,7 +515,7 @@ function Exercises(_ref9) {
         setStarted(true);
         onStart && onStart();
       }
-    }, "Start Quiz")));
+    }, t('start_quiz', lesson.day)));
   }
   var retry = function retry() {
     setExs(buildExercises(lesson));
@@ -488,7 +562,7 @@ function Exercises(_ref9) {
       className: "section"
     }, /*#__PURE__*/React.createElement("div", {
       className: "section-label"
-    }, "Exercises"), /*#__PURE__*/React.createElement("div", {
+    }, t('section_exercises', lesson.day)), /*#__PURE__*/React.createElement("div", {
       className: "exercise-box"
     }, /*#__PURE__*/React.createElement("div", {
       className: "ex-finish"
@@ -497,7 +571,7 @@ function Exercises(_ref9) {
     }, emoji, " ", score.right, " / ", score.total, " correct"), /*#__PURE__*/React.createElement("button", {
       className: "ex-retry-btn",
       onClick: retry
-    }, "Try Again"))));
+    }, t('try_again', lesson.day)))));
   }
   var ex = exs[cur];
   var progress = "".concat(cur + 1, " / ").concat(exs.length);
@@ -506,13 +580,13 @@ function Exercises(_ref9) {
       className: "section"
     }, /*#__PURE__*/React.createElement("div", {
       className: "section-label"
-    }, "Exercises ", /*#__PURE__*/React.createElement("span", {
+    }, t('section_exercises', lesson.day), " ", /*#__PURE__*/React.createElement("span", {
       className: "ex-count"
     }, progress)), /*#__PURE__*/React.createElement("div", {
       className: "exercise-box"
     }, /*#__PURE__*/React.createElement("div", {
       className: "ex-prompt"
-    }, ex.prompt), ex.type === 'listen' ? /*#__PURE__*/React.createElement("div", {
+    }, translatePrompt(ex.prompt, lesson.day)), ex.type === 'listen' ? /*#__PURE__*/React.createElement("div", {
       className: "ex-question"
     }, /*#__PURE__*/React.createElement("button", {
       className: "ex-listen-btn",
@@ -551,13 +625,13 @@ function Exercises(_ref9) {
     className: "section"
   }, /*#__PURE__*/React.createElement("div", {
     className: "section-label"
-  }, "Exercises ", /*#__PURE__*/React.createElement("span", {
+  }, t('section_exercises', lesson.day), " ", /*#__PURE__*/React.createElement("span", {
     className: "ex-count"
   }, progress)), /*#__PURE__*/React.createElement("div", {
     className: "exercise-box"
   }, /*#__PURE__*/React.createElement("div", {
     className: "ex-prompt"
-  }, ex.prompt), ex.question && /*#__PURE__*/React.createElement("div", {
+  }, translatePrompt(ex.prompt, lesson.day)), ex.question && /*#__PURE__*/React.createElement("div", {
     className: "ex-question"
   }, ex.question), /*#__PURE__*/React.createElement("div", {
     className: "ex-typing-row"
@@ -579,7 +653,7 @@ function Exercises(_ref9) {
     className: "ex-check-btn",
     onClick: handleCheck,
     disabled: !answer.trim() || revealed
-  }, "Check")), revealed && /*#__PURE__*/React.createElement("div", {
+  }, t('check_btn', lesson.day))), revealed && /*#__PURE__*/React.createElement("div", {
     className: "ex-feedback ".concat(isRight ? 'correct' : 'wrong')
   }, isRight ? '✓ Correct!' : "\u2717  Answer: ".concat(ex.answers[0]))));
 }
@@ -669,7 +743,7 @@ function App() {
     style: {
       width: pct + '%'
     }
-  })), /*#__PURE__*/React.createElement("span", null, completed.size, "/365 days")), /*#__PURE__*/React.createElement("div", {
+  })), /*#__PURE__*/React.createElement("span", null, completed.size, " ", t('of_365', dayNum))), /*#__PURE__*/React.createElement("div", {
     className: "view-btns"
   }, /*#__PURE__*/React.createElement("button", {
     className: "view-btn ".concat(view === 'day' ? 'active' : ''),
@@ -686,10 +760,11 @@ function App() {
     onClick: function onClick() {
       return setView('review');
     }
-  }, "Review", srsDueCards(srsCards).length > 0 ? " (".concat(srsDueCards(srsCards).length, ")") : '')))), /*#__PURE__*/React.createElement("main", {
+  }, t('view_review', dayNum), srsDueCards(srsCards).length > 0 ? " (".concat(srsDueCards(srsCards).length, ")") : '')))), /*#__PURE__*/React.createElement("main", {
     className: "main"
   }, view === 'review' ? /*#__PURE__*/React.createElement(ReviewMode, {
     cards: srsCards,
+    dayNum: dayNum,
     onUpdate: function onUpdate(updated) {
       setSrsCards(updated);
       srsSave(updated);
@@ -697,6 +772,7 @@ function App() {
   }) : view === 'overview' ? /*#__PURE__*/React.createElement(Overview, {
     curriculum: curriculum,
     completed: completed,
+    dayNum: dayNum,
     setDay: function setDay(d) {
       setDayNum(d);
       setView('day');
@@ -739,16 +815,16 @@ function DayView(_ref0) {
     className: "day-meta"
   }, /*#__PURE__*/React.createElement("span", {
     className: "day-num"
-  }, "Day ", dayNum), /*#__PURE__*/React.createElement("span", {
+  }, t('day_label', dayNum), " ", dayNum), /*#__PURE__*/React.createElement("span", {
     className: "phase-badge",
     style: {
       background: pColor
     }
   }, lesson.phaseName), /*#__PURE__*/React.createElement("span", {
     className: "week-badge"
-  }, "Week ", lesson.week), isDone && /*#__PURE__*/React.createElement("span", {
+  }, t('week_label', dayNum), " ", lesson.week), isDone && /*#__PURE__*/React.createElement("span", {
     className: "complete-badge"
-  }, "\u2713 Complete")), /*#__PURE__*/React.createElement("h2", {
+  }, t('complete_badge', dayNum))), /*#__PURE__*/React.createElement("h2", {
     className: "day-title"
   }, lesson.title)), /*#__PURE__*/React.createElement("div", {
     className: "day-body"
@@ -764,7 +840,7 @@ function DayView(_ref0) {
     className: "section"
   }, /*#__PURE__*/React.createElement("div", {
     className: "section-label"
-  }, "Characters"), /*#__PURE__*/React.createElement("div", {
+  }, t('section_characters', dayNum)), /*#__PURE__*/React.createElement("div", {
     className: "chars-table"
   }, lesson.chars.map(function (c, i) {
     return /*#__PURE__*/React.createElement("div", {
@@ -787,13 +863,13 @@ function DayView(_ref0) {
     className: "section"
   }, /*#__PURE__*/React.createElement("div", {
     className: "section-label"
-  }, "Vocabulary"), function () {
+  }, t('section_vocabulary', dayNum)), function () {
     var hasReadings = lesson.vocab.some(function (v) {
       return v[1] && v[1] !== v[0];
     });
     return /*#__PURE__*/React.createElement("table", {
       className: "vocab-table"
-    }, hasReadings && /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, "Word"), /*#__PURE__*/React.createElement("th", null, "Reading"), /*#__PURE__*/React.createElement("th", null, "Meaning"))), /*#__PURE__*/React.createElement("tbody", null, lesson.vocab.map(function (v, i) {
+    }, hasReadings && /*#__PURE__*/React.createElement("thead", null, /*#__PURE__*/React.createElement("tr", null, /*#__PURE__*/React.createElement("th", null, t('vocab_word', dayNum)), /*#__PURE__*/React.createElement("th", null, t('vocab_reading', dayNum)), /*#__PURE__*/React.createElement("th", null, t('vocab_meaning', dayNum)))), /*#__PURE__*/React.createElement("tbody", null, lesson.vocab.map(function (v, i) {
       return /*#__PURE__*/React.createElement("tr", {
         key: i
       }, /*#__PURE__*/React.createElement("td", null, v[0], /*#__PURE__*/React.createElement("button", {
@@ -808,7 +884,7 @@ function DayView(_ref0) {
     className: "section"
   }, /*#__PURE__*/React.createElement("div", {
     className: "section-label"
-  }, "Grammar Point"), /*#__PURE__*/React.createElement("div", {
+  }, t('section_grammar', dayNum)), /*#__PURE__*/React.createElement("div", {
     className: "grammar-box"
   }, /*#__PURE__*/React.createElement("div", {
     className: "grammar-pattern"
@@ -824,7 +900,7 @@ function DayView(_ref0) {
     className: "section"
   }, /*#__PURE__*/React.createElement("div", {
     className: "section-label"
-  }, "Practice"), /*#__PURE__*/React.createElement("div", {
+  }, t('section_practice', dayNum)), /*#__PURE__*/React.createElement("div", {
     className: "practice-box"
   }, lesson.practice)), lesson.tip && /*#__PURE__*/React.createElement("div", {
     className: "section"
@@ -847,22 +923,23 @@ function DayView(_ref0) {
       return setDay(Math.max(1, dayNum - 1));
     },
     disabled: dayNum === 1
-  }, "\u2190 Previous"), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
+  }, t('nav_prev', dayNum)), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
     className: "day-counter"
-  }, "Day ", dayNum, " of 365"), /*#__PURE__*/React.createElement("button", {
+  }, t('day_label', dayNum), " ", dayNum, " ", t('of_365', dayNum)), /*#__PURE__*/React.createElement("button", {
     className: "nav-btn complete ".concat(isDone ? 'done' : ''),
     onClick: toggleDone
-  }, isDone ? '✕ Mark Incomplete' : '✓ Mark Complete')), /*#__PURE__*/React.createElement("button", {
+  }, isDone ? t('mark_incomplete', dayNum) : t('mark_complete', dayNum))), /*#__PURE__*/React.createElement("button", {
     className: "nav-btn next",
     onClick: function onClick() {
       return setDay(Math.min(365, dayNum + 1));
     },
     disabled: dayNum === 365
-  }, "Next \u2192")));
+  }, t('nav_next', dayNum)));
 }
 function ReviewMode(_ref1) {
   var cards = _ref1.cards,
-    onUpdate = _ref1.onUpdate;
+    onUpdate = _ref1.onUpdate,
+    dayNum = _ref1.dayNum || 1;
   var _React$useStateQ = React.useState(function() { return rndShuffle(srsDueCards(cards)); }),
     _React$useStateQS = _slicedToArray(_React$useStateQ, 2),
     due = _React$useStateQS[0];
@@ -881,9 +958,9 @@ function ReviewMode(_ref1) {
       className: "review-empty-icon"
     }, "\u2705"), /*#__PURE__*/React.createElement("div", {
       className: "review-empty-title"
-    }, "All caught up!"), /*#__PURE__*/React.createElement("div", {
+    }, t('all_caught_up', dayNum)), /*#__PURE__*/React.createElement("div", {
       className: "review-empty-sub"
-    }, "No cards due for review right now."));
+    }, t('no_cards_due', dayNum)));
   }
   if (idx >= due.length) {
     return /*#__PURE__*/React.createElement("div", {
@@ -892,7 +969,7 @@ function ReviewMode(_ref1) {
       className: "review-empty-icon"
     }, "\uD83C\uDF1F"), /*#__PURE__*/React.createElement("div", {
       className: "review-empty-title"
-    }, "Session complete!"), /*#__PURE__*/React.createElement("div", {
+    }, t('session_done', dayNum)), /*#__PURE__*/React.createElement("div", {
       className: "review-empty-sub"
     }, "Reviewed ", due.length, " card", due.length !== 1 ? 's' : '', "."));
   }
@@ -916,7 +993,7 @@ function ReviewMode(_ref1) {
     }
   }, /*#__PURE__*/React.createElement("div", {
     className: "review-card-type"
-  }, card.type === 'char' ? 'Character' : 'Vocabulary'), /*#__PURE__*/React.createElement("div", {
+  }, card.type === 'char' ? t('card_char', dayNum) : t('card_vocab', dayNum)), /*#__PURE__*/React.createElement("div", {
     className: "review-card-front"
   }, card.front, /*#__PURE__*/React.createElement("button", {
     className: "speak-btn",
@@ -936,31 +1013,31 @@ function ReviewMode(_ref1) {
     className: "review-meaning"
   }, card.back)) : /*#__PURE__*/React.createElement("div", {
     className: "review-card-hint"
-  }, "tap to reveal")), flipped && /*#__PURE__*/React.createElement("div", {
+  }, t('tap_reveal', dayNum))), flipped && /*#__PURE__*/React.createElement("div", {
     className: "review-btns"
   }, /*#__PURE__*/React.createElement("button", {
     className: "review-btn again",
     onClick: function onClick() {
       return rate(0);
     }
-  }, "Again"), /*#__PURE__*/React.createElement("button", {
+  }, t('btn_again', dayNum)), /*#__PURE__*/React.createElement("button", {
     className: "review-btn hard",
     onClick: function onClick() {
       return rate(1);
     }
-  }, "Hard"), /*#__PURE__*/React.createElement("button", {
+  }, t('btn_hard', dayNum)), /*#__PURE__*/React.createElement("button", {
     className: "review-btn good",
     onClick: function onClick() {
       return rate(2);
     }
-  }, "Good"), /*#__PURE__*/React.createElement("button", {
+  }, t('btn_good', dayNum)), /*#__PURE__*/React.createElement("button", {
     className: "review-btn easy",
     onClick: function onClick() {
       return rate(3);
     }
-  }, "Easy")), !flipped && /*#__PURE__*/React.createElement("div", {
+  }, t('btn_easy', dayNum))), !flipped && /*#__PURE__*/React.createElement("div", {
     className: "review-flip-hint"
-  }, "Click the card to see the answer"));
+  }, t('click_reveal', dayNum)));
 }
 function Overview(_ref10) {
   var curriculum = _ref10.curriculum,


### PR DESCRIPTION
## Summary
Implements a progressive UI translation system that dynamically switches the interface from English to Japanese as learning-related vocabulary is introduced throughout the curriculum.

## Key Changes
- Added progressive UI translation infrastructure to `index.html` with a mapping system that tracks when Japanese terms are taught
- Each translatable UI element is defined with English (`en`) and Japanese (`ja`) versions, along with a `since` property indicating when the term is introduced in the curriculum
- Significantly expanded `curriculum.js` with new curriculum content and supporting logic for the translation system

## Implementation Details
- The translation system uses a declarative approach where UI strings are mapped to curriculum milestones
- As users progress through lessons and encounter new vocabulary, the corresponding UI elements automatically update to their Japanese equivalents
- This creates an immersive learning experience where the interface itself becomes part of the curriculum
- The system maintains backward compatibility by defaulting to English until terms are formally introduced

https://claude.ai/code/session_01Kud7maxe7nXTQ9trBjbVgM